### PR TITLE
Adding duplication of surveys for quick cloning (Task #5575)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         }
     },
     "require": {
-        "qobo/cakephp-utils": "^7.0",
-        "riesenia/cakephp-duplicatable": "^3.0"
+        "qobo/cakephp-utils": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit":"^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         }
     },
     "require": {
-        "qobo/cakephp-utils": "^7.0"
+        "qobo/cakephp-utils": "^7.0",
+        "riesenia/cakephp-duplicatable": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit":"^5.0",

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -71,6 +71,31 @@ class SurveysController extends AppController
     }
 
     /**
+     * Publish method
+     *
+     * @param string|null $id Survey id.
+     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function duplicate($id = null)
+    {
+        $this->autoRender = false;
+
+        if ($this->request->is(['post', 'put', 'patch'])) {
+            $duplicated = $this->Surveys->duplicate($id);
+            if ($duplicated) {
+                // @NOTE: saving parent_id as Duplicatable unsets origin id
+                $duplicated = $this->Surveys->patchEntity($duplicated, ['parent_id' => $id]);
+                $duplicated = $this->Surveys->save($duplicated);
+
+                $this->Flash->success(__('Survey was successfully duplicated'));
+
+                return $this->redirect(['action' => 'index']);
+            }
+            $this->Flash->error(__('Couldn\'t duplicate the survey data'));
+        }
+    }
+    /**
      * Add method
      *
      * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -39,6 +39,18 @@ class SurveysTable extends Table
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+
+        $this->addBehavior('Duplicatable.Duplicatable', [
+            'finder' => 'all',
+            'contain' => ['SurveyQuestions.SurveyAnswers'],
+            'remove' => ['publish_date', 'created', 'modified'],
+            'append' => ['name' => ' - (duplicated: ' . date('Y-m-d H:i', time()) . ')']
+        ]);
+
+        $this->hasMany('SurveyQuestions', [
+            'foreignKey' => 'survey_id',
+            'className' => 'Qobo/Survey.SurveyQuestions',
+        ]);
     }
 
     /**

--- a/src/Template/Surveys/index.ctp
+++ b/src/Template/Surveys/index.ctp
@@ -41,6 +41,7 @@ $options['title'] = 'Surveys';
                             <td><?= h($survey->created) ?></td>
                             <td><?= h($survey->publish_date) ?></td>
                             <td class="actions">
+                                <?= $this->Form->postLink(__('Duplicate'), ['action' => 'duplicate', $survey->id]);?>
                                 <?php if (!empty($survey->publish_date)) : ?>
                                 <?= $this->Html->link(__('Publish'), ['action' => 'publish', $survey->id]);?>
                                 <?= $this->Html->link(__('View'), ['action' => 'view', $survey->id]) ?>


### PR DESCRIPTION
- Using `Duplicatable` behavior for cloning survey associated questions/answers and survey itself.

In order to use this behavior please install the plugin on your application:
```
composer require riesenia/cakephp-duplicatable
```

And don't forget to load this plugin in `config/bootstrap.php`.