### PR TITLE
Adding reference_id to plugin tables (task #5751)

### DIFF
--- a/config/Migrations/20180411083243_AddReferenceIdToSurveys.php
+++ b/config/Migrations/20180411083243_AddReferenceIdToSurveys.php
@@ -1,0 +1,23 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddReferenceIdToSurveys extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('surveys');
+        $table->addColumn('reference_id', 'string', [
+            'default' => null,
+            'null' => true,
+            'after' => 'id'
+        ])->addIndex(['reference_id'], ['name' => 'idx_reference_id']);
+        $table->update();
+    }
+}

--- a/config/Migrations/20180411084226_AddReferenceIdToSurveyQuestions.php
+++ b/config/Migrations/20180411084226_AddReferenceIdToSurveyQuestions.php
@@ -1,0 +1,23 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddReferenceIdToSurveyQuestions extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('survey_questions');
+        $table->addColumn('reference_id', 'string', [
+            'default' => null,
+            'null' => true,
+            'after' => 'id',
+        ])->addIndex(['reference_id'], ['name' => 'idx_reference_id']);
+        $table->update();
+    }
+}

--- a/config/Migrations/20180411084406_AddReferenceIdToSurveyAnswers.php
+++ b/config/Migrations/20180411084406_AddReferenceIdToSurveyAnswers.php
@@ -1,0 +1,23 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddReferenceIdToSurveyAnswers extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('survey_answers');
+        $table->addColumn('reference_id', 'string', [
+            'default' => null,
+            'null' => true,
+            'after' => 'id',
+        ])->addIndex(['reference_id'], ['name' => 'idx_reference_id']);
+        $table->update();
+    }
+}


### PR DESCRIPTION
In case the survey is about to be exported, we let
storing original reference to the source records.