### PR TITLE
Changing user_id column to be non-required (task #5829)

### DIFF
--- a/config/Migrations/20180423073241_AlterSurveyResults.php
+++ b/config/Migrations/20180423073241_AlterSurveyResults.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AlterSurveyResults extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('survey_results');
+        $table->changeColumn('user_id', 'uuid', [
+            'default' => null,
+            'null' => true,
+        ]);
+        $table->update();
+    }
+}

--- a/src/Model/Table/SurveyResultsTable.php
+++ b/src/Model/Table/SurveyResultsTable.php
@@ -111,7 +111,6 @@ class SurveyResultsTable extends Table
         $rules->add($rules->existsIn(['survey_id'], 'Surveys'));
         $rules->add($rules->existsIn(['survey_question_id'], 'SurveyQuestions'));
         $rules->add($rules->existsIn(['survey_answer_id'], 'SurveyAnswers'));
-        $rules->add($rules->existsIn(['user_id'], 'Users'));
 
         return $rules;
     }


### PR DESCRIPTION
Surveys might be linked not only to user ids. In some cases,
they can be also anonymous, thus the linkage key will be stored
in the aggregate (HABTM) tables.