### PR TITLE
Adding submit fields into survey preview as PoC (task #5855)

### DIFF
--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -122,7 +122,6 @@ class SurveysController extends AppController
         if ($this->request->is(['post', 'put', 'patch'])) {
             $this->SurveyResults = TableRegistry::get('Qobo/Survey.SurveyResults');
             $user = $this->Auth->user();
-
             if (empty($this->request->data['SurveyResults'])) {
                 $this->Flash->error(__('Please submit your survey answers'));
 
@@ -133,11 +132,11 @@ class SurveysController extends AppController
                 $results = $this->SurveyResults->getResults($item, [
                     'user' => $user,
                     'survey' => $survey,
+                    'data' => $this->request->data
                 ]);
 
                 $data = array_merge($data, $results);
             }
-
             foreach ($data as $k => $surveyResult) {
                 $saved[] = $this->SurveyResults->saveData($surveyResult);
             }

--- a/src/Model/Table/SurveyResultsTable.php
+++ b/src/Model/Table/SurveyResultsTable.php
@@ -186,5 +186,4 @@ class SurveyResultsTable extends Table
 
         return $result;
     }
-
 }

--- a/src/Model/Table/SurveyResultsTable.php
+++ b/src/Model/Table/SurveyResultsTable.php
@@ -139,6 +139,8 @@ class SurveyResultsTable extends Table
             'survey_id' => $options['survey']->id,
             'survey_question_id' => $data['survey_question_id'],
             'result' => !empty($data['result']) ? $data['result'] : '',
+            'submit_id' => !empty($options['data']['submit_id']) ? $options['data']['submit_id'] : null,
+            'submit_date' => !empty($options['data']['submit_date']) ? $options['data']['submit_date'] : null,
         ];
 
         if (!is_array($data['survey_answer_id'])) {
@@ -184,4 +186,5 @@ class SurveyResultsTable extends Table
 
         return $result;
     }
+
 }

--- a/src/Template/Surveys/preview.ctp
+++ b/src/Template/Surveys/preview.ctp
@@ -9,6 +9,9 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
+use Cake\Utility\Text;
+
 $options['title'] = __('Preview Survey: {0}', $survey->name);
 $count = 1;
 ?>
@@ -28,6 +31,8 @@ $count = 1;
 
 <section class="content">
 <?= $this->Form->create($survey); ?>
+<?= $this->Form->hidden('submit_id', ['value' => Text::uuid()]) ?>
+<?= $this->Form->hidden('submit_date', ['value' => date('Y-m-d H:i:s', time())]) ?>
 <?php foreach ($survey->survey_questions as $k => $question) : ?>
     <div class="box box-primary">
         <div class="box-header with-border">


### PR DESCRIPTION
Adding `submit_id` and `submit_date` as part of form hidden fields into `preview.ctp` as Proof of Concept.