### PR TITLE
CakePHP 3.6 support and PHPStan (task #8244)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.twig]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,52 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+.htaccess text
+*.css text diff=css
+*.ctp text diff=php
+*.default text
+*.html text diff=html
+*.ini text
+*.js text
+*.md text
+*.php text diff=php
+*.po text
+*.properties text
+*.sql text
+*.svg text
+*.txt text
+*.xml text
+*.yml text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.pem eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+composer binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.phar binary
+
+# Web fonts are binary
+*.otf binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+# Treat zip files as binary
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,41 @@
+# Project specific files #
+##########################
 build/
 vendor/
+cghooks.lock
+
 composer.lock
 config/Migrations/schema-dump-default.lock
 config/Migrations/schema-dump-test.lock
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Tool specific files #
+#######################
+# vim
+*~
+*.swp
+*.swo
+# sublime text & textmate
+*.sublime-*
+*.stTheme.cache
+*.tmlanguage.cache
+*.tmPreferences.cache
+# Eclipse
+.settings/*
+# JetBrains, aka PHPStorm, IntelliJ IDEA
+.idea/*
+# NetBeans
+nbproject/*
+# Visual Studio Code
+.vscode
+# Sass preprocessor
+.sass-cache/

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,7 @@
 linters:
   phpcs:
     standard: CakePHP
-    extensions: '.php,.ctp'
+    extensions: 'php,ctp'
+    exclude: 'Generic.Commenting.Todo'
 files:
-  ignore: ['config/*', 'tests/*']
+    ignore: ['webroot/plugins/*']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-#This Travis config template file was taken from https://github.com/FriendsOfCake/travis
-sudo: true
-dist: trusty
-
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - nightly
+dist: trusty
+
+sudo: false
 
 cache:
   directories:
@@ -21,25 +16,39 @@ env:
 
 matrix:
   fast_finish: true
+
   allow_failures:
+    - php: 7.3
     - php: nightly
+
+  include:
+    - php: 7.1
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+    - php: 7.2
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: 7.3
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: nightly
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
 
 install:
   - composer validate --strict
   - composer install --no-interaction --no-progress --no-suggest
-  - mkdir -p build/logs
+  - mkdir -p build/test-coverage build/test-results
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS cakephp_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'; fi"
 
 script:
-  - vendor/bin/phpcs
-  - if [ $TRAVIS_PHP_VERSION != "7.1" ]; then vendor/bin/phpunit --no-coverage; else vendor/bin/phpunit; fi
+  - if [[ $PHPCS = 1 ]]; then ./vendor/bin/phpcs; fi
+  - if [[ $COVERAGE = 0 ]]; then ./vendor/bin/phpunit --no-coverage; fi
+  - if [[ $COVERAGE = 1 ]]; then ./vendor/bin/phpunit; fi
+  - if [[ $PHPSTAN = 1 ]]; then ./vendor/bin/phpstan analyse; fi
 
 after_success:
   - curl -s https://codecov.io/bash > /tmp/codecov.sh
   - chmod +x /tmp/codecov.sh
-  - /tmp/codecov.sh -s build/logs
+  - /tmp/codecov.sh -s build/test-results
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
 
   include:
     - php: 7.1
-      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=1
     - php: 7.2
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: 7.3
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: nightly
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
 
 install:
   - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -1,34 +1,58 @@
 {
     "name": "qobo/cakephp-survey",
     "description": "CakePHP plugin for handling surveys",
+    "keywords": ["cakephp", "surveys"],
     "type": "cakephp-plugin",
     "license": "MIT",
+    "homepage": "https://www.qobo.biz",
     "authors": [
         {
             "name": "Qobo Ltd",
-            "email": "info@qobo.biz",
+            "email": "support@qobo.biz",
             "homepage": "https://www.qobo.biz",
             "role": "Developer"
         }
     ],
+    "support": {
+        "issues": "https://github.com/QoboLtd/cakephp-survey/issues",
+        "source": "https://github.com/QoboLtd/cakephp-survey"
+    },
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true
+    },
     "require": {
-        "qobo/cakephp-utils": "^9.0",
+        "qobo/cakephp-utils": "^10.0",
         "muffin/slug": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit":"^6.0",
-        "cakephp/cakephp-codesniffer": "^3.0"
+        "qobo/cakephp-composer-dev": "^v1.0"
     },
     "autoload": {
         "psr-4": {
-            "Qobo\\Survey\\": "src",
-            "Qobo\\Survey\\Test\\Fixture\\": "tests\\Fixture"
+            "Qobo\\Survey\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Qobo\\Survey\\Test\\": "tests",
-            "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
+            "Qobo\\Survey\\Test\\": "tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
-    }
+    },
+    "scripts": {
+        "test": [
+            "phpcs",
+            "phpunit --no-coverage"
+        ],
+        "test-coverage": [
+            "phpcs",
+            "phpunit"
+        ],
+        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    },
+    "scripts-descriptions": {
+        "test": "Runs phpcs and phpunit without coverage",
+        "test-coverage": "Runs phpcs and phpunit with coverage enabled"
+    },
+    "prefer-stable": true
 }

--- a/config/routes.php
+++ b/config/routes.php
@@ -5,7 +5,7 @@ Router::plugin(
     'Qobo/Survey',
     ['path' => '/surveys'],
     function ($routes) {
-        $routes->extensions(['json']);
+        $routes->setExtensions(['json']);
 
         $routes->scope('/survey', function ($routes) {
             $routes->connect(

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,16 +9,15 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP" />
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP">
+        <exclude name="Generic.Commenting.Todo" />
+    </rule>
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />
 
     <!-- Assume UTF-8 -->
     <config name="encoding" value="UTF-8" />
-
-    <!-- Extensions to check -->
-    <arg name="extensions" value="php,inc,ctp,js,css" />
 
     <!-- Use colors -->
     <arg name="colors" />
@@ -29,7 +28,12 @@
     <!-- Files and directories to check -->
     <file>./src/</file>
     <file>./tests/</file>
+    <file>./config/</file>
     <file>./webroot/</file>
-    <!-- Files and directories to ignore -->
-    <arg name="ignore" value="webroot/plugins/" />
+
+    <!-- Exclude patterns -->
+    <exclude-pattern>config/Migrations/*</exclude-pattern>
+    <exclude-pattern>config/Seeds/*</exclude-pattern>
+    <exclude-pattern>webroot/plugins/*</exclude-pattern>
+    <exclude-pattern>*\.min\.(css|js)</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,14 @@
+parameters:
+    level: 7
+    paths:
+        - src
+        - tests
+        - webroot
+    autoload_files:
+        - tests/bootstrap.php
+    earlyTerminatingMethodCalls:
+        Cake\Console\Shell:
+            - abort
+includes:
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - vendor/timeweb/phpstan-enum/extension.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	syntaxCheck="false"
-	bootstrap="./tests/bootstrap.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="./tests/bootstrap.php"
     verbose="true"
-	>
-	<php>
-		<ini name="memory_limit" value="-1"/>
-		<ini name="apc.enable_cli" value="1"/>
-	</php>
-
-	<filter>
-		<whitelist>
-            <directory suffix=".php">./src/</directory>
-            <directory suffix=".php">./webroot/</directory>
-		</whitelist>
-	</filter>
+    >
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="apc.enable_cli" value="1"/>
+    </php>
 
     <logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-		<log type="coverage-html" target="build/coverage"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-		<log type="junit" target="build/logs/junit.xml"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="build/test-coverage"/>
+        <log type="coverage-clover" target="build/test-results/clover.xml"/>
+        <log type="coverage-crap4j" target="build/test-results/crap4j.xml"/>
+        <log type="junit" target="build/test-results/junit.xml"/>
     </logging>
+
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="surveys">
+            <directory>tests/TestCase</directory>
+        </testsuite>
+    </testsuites>
 
     <!-- Setup a listener for fixtures -->
     <listeners>
@@ -38,11 +37,11 @@
         </listener>
     </listeners>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="Plugin Test Suite">
-            <directory>./tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
-
+    <!-- Ignore vendor tests in code coverage reports -->
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">./webroot/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -38,7 +38,7 @@ class AppController extends BaseController
      * @param string $id of the instance
      * @param string $direction of the movement
      *
-     * @return \Cake\Network\Response|void|null
+     * @return \Cake\Http\Response|void|null
      */
     public function move(string $id, string $direction)
     {

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -16,6 +16,7 @@ use Cake\Log\Log;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Exception;
+use RuntimeException;
 
 class AppController extends BaseController
 {
@@ -42,6 +43,9 @@ class AppController extends BaseController
      */
     public function move(string $id, string $direction)
     {
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveysTable
+         */
         $table = TableRegistry::get('Qobo/Survey.' . $this->name);
         $direction = strtolower($direction);
 
@@ -57,6 +61,7 @@ class AppController extends BaseController
             }
         } catch (Exception $e) {
             Log::warning($e->getMessage());
+            throw new RuntimeException("Couldn't move entity record", 0, $e);
         }
 
         return $this->redirect($this->referer());

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -35,12 +35,12 @@ class AppController extends BaseController
     /**
      * Change order of the record
      *
-     * @param uuid $id of the instance
+     * @param string $id of the instance
      * @param string $direction of the movement
      *
-     * @return \Cake\Network\Response
+     * @return \Cake\Network\Response|void|null
      */
-    public function move($id, $direction)
+    public function move(string $id, string $direction)
     {
         $table = TableRegistry::get('Qobo/Survey.' . $this->name);
         $direction = strtolower($direction);

--- a/src/Controller/SurveyAnswersController.php
+++ b/src/Controller/SurveyAnswersController.php
@@ -41,10 +41,9 @@ class SurveyAnswersController extends AppController
      * @param string $questionId id of an instance
      * @param string|null $id Survey Answer id.
      *
-     * @return \Cake\Http\Response|void
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null
      */
-    public function view($surveyId, $questionId = null, $id = null)
+    public function view(string $surveyId, string $questionId = null, string $id = null)
     {
         $survey = $this->Surveys->getSurveyData($surveyId, false);
         $questionTypes = $this->SurveyAnswers->SurveyQuestions->getQuestionTypes();
@@ -62,9 +61,9 @@ class SurveyAnswersController extends AppController
      * @param string $surveyId it's either slug or survey id.
      * @param string $questionId of related instance
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
-    public function add($surveyId = null, $questionId = null)
+    public function add(string $surveyId = null, string $questionId = null)
     {
         $surveyAnswer = $this->SurveyAnswers->newEntity();
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -77,11 +76,11 @@ class SurveyAnswersController extends AppController
             $surveyAnswer = $this->SurveyAnswers->patchEntity($surveyAnswer, $data);
 
             if ($this->SurveyAnswers->save($surveyAnswer)) {
-                $this->Flash->success(__('The survey answer has been saved.'));
+                $this->Flash->success((string)__('The survey answer has been saved.'));
 
                 return $this->redirect($redirect);
             }
-            $this->Flash->error(__('The survey answer could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The survey answer could not be saved. Please, try again.'));
         }
 
         $this->set(compact('surveyAnswer', 'survey', 'question'));
@@ -94,10 +93,9 @@ class SurveyAnswersController extends AppController
      * @param string $questionId of related question instance
      * @param string|null $id Survey Answer id.
      *
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Network\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects on successful edit, renders view otherwise.
      */
-    public function edit($surveyId, $questionId = null, $id = null)
+    public function edit(string $surveyId, string $questionId = null, string $id = null)
     {
         $surveyAnswer = $this->SurveyAnswers->get($id);
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -110,11 +108,11 @@ class SurveyAnswersController extends AppController
 
             $surveyAnswer = $this->SurveyAnswers->patchEntity($surveyAnswer, $data);
             if ($this->SurveyAnswers->save($surveyAnswer)) {
-                $this->Flash->success(__('The survey answer has been saved.'));
+                $this->Flash->success((string)__('The survey answer has been saved.'));
 
                 return $this->redirect($redirect);
             }
-            $this->Flash->error(__('The survey answer could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The survey answer could not be saved. Please, try again.'));
         }
 
         $this->set(compact('surveyAnswer', 'survey', 'question'));
@@ -127,10 +125,9 @@ class SurveyAnswersController extends AppController
      * @param string $questionId of related question id instance
      * @param string|null $id Survey Answer id.
      *
-     * @return \Cake\Http\Response|null Redirects to index.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects to index.
      */
-    public function delete($surveyId, $questionId = null, $id = null)
+    public function delete(string $surveyId, string $questionId = null, string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
 
@@ -139,9 +136,9 @@ class SurveyAnswersController extends AppController
         $redirect = ['controller' => 'SurveyQuestions', 'action' => 'view', $surveyId, $questionId];
 
         if ($this->SurveyAnswers->delete($answer)) {
-            $this->Flash->success(__('The survey answer has been deleted.'));
+            $this->Flash->success((string)__('The survey answer has been deleted.'));
         } else {
-            $this->Flash->error(__('The survey answer could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The survey answer could not be deleted. Please, try again.'));
         }
 
         return $this->redirect($redirect);

--- a/src/Controller/SurveyAnswersController.php
+++ b/src/Controller/SurveyAnswersController.php
@@ -43,12 +43,12 @@ class SurveyAnswersController extends AppController
      * View method
      *
      * @param string $surveyId it's either slug or survey id.
-     * @param string $questionId id of an instance
+     * @param string|null $questionId id of an instance
      * @param string|null $id Survey Answer id.
      *
      * @return \Cake\Http\Response|void|null
      */
-    public function view(string $surveyId, string $questionId = null, string $id = null)
+    public function view(string $surveyId, ?string $questionId, ?string $id)
     {
         $survey = $this->Surveys->getSurveyData($surveyId, false);
         $questionTypes = $this->SurveyAnswers->SurveyQuestions->getQuestionTypes();

--- a/src/Controller/SurveyAnswersController.php
+++ b/src/Controller/SurveyAnswersController.php
@@ -17,6 +17,7 @@ use Qobo\Survey\Controller\AppController;
 /**
  * SurveyAnswers Controller
  *
+ * @property \Qobo\Survey\Model\Table\SurveysTable $Surveys
  * @property \Qobo\Survey\Model\Table\SurveyAnswersTable $SurveyAnswers
  *
  * @method \Qobo\Survey\Model\Entity\SurveyAnswer[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
@@ -32,7 +33,11 @@ class SurveyAnswersController extends AppController
     public function initialize()
     {
         parent::initialize();
-        $this->Surveys = TableRegistry::get('Qobo/Survey.Surveys');
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveysTable $table
+         */
+        $table = TableRegistry::get('Qobo/Survey.Surveys');
+        $this->Surveys = $table;
     }
     /**
      * View method

--- a/src/Controller/SurveyAnswersController.php
+++ b/src/Controller/SurveyAnswersController.php
@@ -64,11 +64,11 @@ class SurveyAnswersController extends AppController
      * Add method
      *
      * @param string $surveyId it's either slug or survey id.
-     * @param string $questionId of related instance
+     * @param string|null $questionId of related instance
      *
      * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
-    public function add(string $surveyId = null, string $questionId = null)
+    public function add(string $surveyId, ?string $questionId)
     {
         $surveyAnswer = $this->SurveyAnswers->newEntity();
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -100,7 +100,7 @@ class SurveyAnswersController extends AppController
      *
      * @return \Cake\Http\Response|void|null Redirects on successful edit, renders view otherwise.
      */
-    public function edit(string $surveyId, string $questionId = null, string $id = null)
+    public function edit(string $surveyId, string $questionId, ?string $id)
     {
         $surveyAnswer = $this->SurveyAnswers->get($id);
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -132,7 +132,7 @@ class SurveyAnswersController extends AppController
      *
      * @return \Cake\Http\Response|void|null Redirects to index.
      */
-    public function delete(string $surveyId, string $questionId = null, string $id = null)
+    public function delete(string $surveyId, string $questionId, ?string $id)
     {
         $this->request->allowMethod(['post', 'delete']);
 

--- a/src/Controller/SurveyQuestionsController.php
+++ b/src/Controller/SurveyQuestionsController.php
@@ -60,7 +60,7 @@ class SurveyQuestionsController extends AppController
      * @param string|null $id Survey Question id.
      * @return \Cake\Http\Response|void|null
      */
-    public function view(string $surveyId, string $id = null)
+    public function view(string $surveyId, ?string $id)
     {
         $query = $this->SurveyQuestions->find();
         $query->where(['SurveyQuestions.id' => $id]);
@@ -86,7 +86,7 @@ class SurveyQuestionsController extends AppController
      * @param string|null $id Survey Question id.
      * @return \Cake\Http\Response|void|null
      */
-    public function preview(string $surveyId, string $id = null)
+    public function preview(string $surveyId, ?string $id)
     {
         $savedResults = [];
         $surveyQuestion = $this->SurveyQuestions->get($id, [
@@ -142,7 +142,7 @@ class SurveyQuestionsController extends AppController
      * @param string|null $id Survey Question id.
      * @return \Cake\Http\Response|void|null Redirects on successful edit, renders view otherwise.
      */
-    public function edit(string $surveyId, string $id = null)
+    public function edit(string $surveyId, ?string $id)
     {
         $survey = $this->Surveys->getSurveyData($surveyId);
         $surveyQuestion = $this->SurveyQuestions->get($id);
@@ -176,7 +176,7 @@ class SurveyQuestionsController extends AppController
      * @param string|null $id Survey Question id.
      * @return \Cake\Http\Response|void|null Redirects to index.
      */
-    public function delete(string $surveyId, string $id = null)
+    public function delete(string $surveyId, ?string $id)
     {
         $this->request->allowMethod(['post', 'delete']);
 

--- a/src/Controller/SurveyQuestionsController.php
+++ b/src/Controller/SurveyQuestionsController.php
@@ -15,6 +15,10 @@ use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
 use Qobo\Survey\Controller\AppController;
 
+/**
+ * @property \Qobo\Survey\Model\Table\SurveysTable $Surveys
+ * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable $SurveyQuestions
+ */
 class SurveyQuestionsController extends AppController
 {
     /**
@@ -26,7 +30,11 @@ class SurveyQuestionsController extends AppController
     public function initialize(): void
     {
         parent::initialize();
-        $this->Surveys = TableRegistry::get('Qobo/Survey.Surveys');
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveysTable $table
+         */
+        $table = TableRegistry::get('Qobo/Survey.Surveys');
+        $this->Surveys = $table;
     }
 
     /**
@@ -109,7 +117,11 @@ class SurveyQuestionsController extends AppController
         $survey = $this->Surveys->getSurveyData($surveyId);
 
         if ($this->request->is(['post', 'put', 'patch'])) {
-            $surveyQuestion = $this->SurveyQuestions->patchEntity($surveyQuestion, $this->request->getData());
+            /**
+             * @var array $data
+             */
+            $data = $this->request->getData();
+            $surveyQuestion = $this->SurveyQuestions->patchEntity($surveyQuestion, $data);
             $saved = $this->SurveyQuestions->save($surveyQuestion);
 
             if ($saved) {
@@ -136,7 +148,11 @@ class SurveyQuestionsController extends AppController
         $surveyQuestion = $this->SurveyQuestions->get($id);
 
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $surveyQuestion = $this->SurveyQuestions->patchEntity($surveyQuestion, $this->request->getData());
+            /**
+             * @var array $data
+             */
+            $data = $this->request->getData();
+            $surveyQuestion = $this->SurveyQuestions->patchEntity($surveyQuestion, $data);
             if ($this->SurveyQuestions->save($surveyQuestion)) {
                 $this->Flash->success((string)__('The survey question has been saved.'));
 

--- a/src/Controller/SurveyQuestionsController.php
+++ b/src/Controller/SurveyQuestionsController.php
@@ -146,6 +146,7 @@ class SurveyQuestionsController extends AppController
     {
         $survey = $this->Surveys->getSurveyData($surveyId);
         $surveyQuestion = $this->SurveyQuestions->get($id);
+        $redirect = ['controller' => 'Surveys', 'action' => 'view', $surveyId];
 
         if ($this->request->is(['patch', 'post', 'put'])) {
             /**
@@ -156,7 +157,9 @@ class SurveyQuestionsController extends AppController
             if ($this->SurveyQuestions->save($surveyQuestion)) {
                 $this->Flash->success((string)__('The survey question has been saved.'));
 
-                $redirect = ['controller' => 'SurveyQuestions', 'action' => 'view', $survey->slug, $surveyQuestion->id];
+                if (! empty($survey)) {
+                    $redirect = ['controller' => 'SurveyQuestions', 'action' => 'view', $survey->get('slug'), $surveyQuestion->get('id')];
+                }
 
                 return $this->redirect($redirect);
             }
@@ -179,7 +182,11 @@ class SurveyQuestionsController extends AppController
 
         $question = $this->SurveyQuestions->get($id);
         $survey = $this->Surveys->getSurveyData($surveyId);
-        $surveyId = empty($survey->slug) ? $survey->id : $survey->slug;
+
+        if (! empty($survey)) {
+            $surveyId = empty($survey->get('slug')) ? $survey->get('id') : $survey->get('slug');
+        }
+
         $redirect = ['controller' => 'Surveys', 'action' => 'view', $surveyId];
 
         if ($this->SurveyQuestions->delete($question)) {

--- a/src/Controller/SurveyQuestionsController.php
+++ b/src/Controller/SurveyQuestionsController.php
@@ -23,7 +23,7 @@ class SurveyQuestionsController extends AppController
      *
      * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
         parent::initialize();
         $this->Surveys = TableRegistry::get('Qobo/Survey.Surveys');
@@ -37,7 +37,7 @@ class SurveyQuestionsController extends AppController
      * @param \Cake\Event\Event $event broadcasted.
      * @return void
      */
-    public function beforeFilter(Event $event)
+    public function beforeFilter(Event $event): void
     {
         parent::beforeFilter($event);
 
@@ -50,10 +50,9 @@ class SurveyQuestionsController extends AppController
      *
      * @param string $surveyId of the survey or either its slug
      * @param string|null $id Survey Question id.
-     * @return \Cake\Http\Response|void
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null
      */
-    public function view($surveyId, $id = null)
+    public function view(string $surveyId, string $id = null)
     {
         $query = $this->SurveyQuestions->find();
         $query->where(['SurveyQuestions.id' => $id]);
@@ -77,10 +76,9 @@ class SurveyQuestionsController extends AppController
      *
      * @param string $surveyId of the survey or either its slug
      * @param string|null $id Survey Question id.
-     * @return \Cake\Http\Response|void
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null
      */
-    public function preview($surveyId, $id = null)
+    public function preview(string $surveyId, string $id = null)
     {
         $savedResults = [];
         $surveyQuestion = $this->SurveyQuestions->get($id, [
@@ -103,9 +101,9 @@ class SurveyQuestionsController extends AppController
      * Add method
      *
      * @param string $surveyId of the survey or either its slug
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
-    public function add($surveyId)
+    public function add(string $surveyId)
     {
         $surveyQuestion = $this->SurveyQuestions->newEntity();
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -115,11 +113,11 @@ class SurveyQuestionsController extends AppController
             $saved = $this->SurveyQuestions->save($surveyQuestion);
 
             if ($saved) {
-                $this->Flash->success(__('The survey question has been saved.'));
+                $this->Flash->success((string)__('The survey question has been saved.'));
 
                 return $this->redirect(['controller' => 'SurveyAnswers', 'action' => 'add', $surveyId, $surveyQuestion->id]);
             }
-            $this->Flash->error(__('The survey question could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The survey question could not be saved. Please, try again.'));
         }
 
         $this->set(compact('surveyQuestion', 'survey'));
@@ -130,10 +128,9 @@ class SurveyQuestionsController extends AppController
      *
      * @param string $surveyId of the survey or either its slug
      * @param string|null $id Survey Question id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Network\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects on successful edit, renders view otherwise.
      */
-    public function edit($surveyId, $id = null)
+    public function edit(string $surveyId, string $id = null)
     {
         $survey = $this->Surveys->getSurveyData($surveyId);
         $surveyQuestion = $this->SurveyQuestions->get($id);
@@ -141,13 +138,13 @@ class SurveyQuestionsController extends AppController
         if ($this->request->is(['patch', 'post', 'put'])) {
             $surveyQuestion = $this->SurveyQuestions->patchEntity($surveyQuestion, $this->request->getData());
             if ($this->SurveyQuestions->save($surveyQuestion)) {
-                $this->Flash->success(__('The survey question has been saved.'));
+                $this->Flash->success((string)__('The survey question has been saved.'));
 
                 $redirect = ['controller' => 'SurveyQuestions', 'action' => 'view', $survey->slug, $surveyQuestion->id];
 
                 return $this->redirect($redirect);
             }
-            $this->Flash->error(__('The survey question could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The survey question could not be saved. Please, try again.'));
         }
 
         $this->set(compact('surveyQuestion', 'survey'));
@@ -158,10 +155,9 @@ class SurveyQuestionsController extends AppController
      *
      * @param string $surveyId of the survey or either its slug
      * @param string|null $id Survey Question id.
-     * @return \Cake\Http\Response|null Redirects to index.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects to index.
      */
-    public function delete($surveyId, $id = null)
+    public function delete(string $surveyId, string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
 
@@ -171,9 +167,9 @@ class SurveyQuestionsController extends AppController
         $redirect = ['controller' => 'Surveys', 'action' => 'view', $surveyId];
 
         if ($this->SurveyQuestions->delete($question)) {
-            $this->Flash->success(__('The survey question has been deleted.'));
+            $this->Flash->success((string)__('The survey question has been deleted.'));
         } else {
-            $this->Flash->error(__('The survey question could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The survey question could not be deleted. Please, try again.'));
         }
 
         return $this->redirect($redirect);

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -29,7 +29,7 @@ class SurveysController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Http\Response|void
+     * @return \Cake\Http\Response|void|null
      */
     public function index()
     {
@@ -45,7 +45,7 @@ class SurveysController extends AppController
      * @param \Cake\Event\Event $event broadcasted.
      * @return void
      */
-    public function beforeFilter(Event $event)
+    public function beforeFilter(Event $event): void
     {
         parent::beforeFilter($event);
 
@@ -57,10 +57,9 @@ class SurveysController extends AppController
      * View method
      *
      * @param string|null $id Survey id.
-     * @return \Cake\Http\Response|void
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null
      */
-    public function view($id = null)
+    public function view(string $id = null)
     {
         $this->SurveyQuestions = TableRegistry::get('Qobo/Survey.SurveyQuestions');
         $this->SurveyResults = TableRegistry::get('Qobo/Survey.SurveyResults');
@@ -89,10 +88,9 @@ class SurveysController extends AppController
      * Publish method
      *
      * @param string|null $id Survey id.
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
-    public function publish($id = null)
+    public function publish(string $id = null)
     {
         $survey = $this->Surveys->getSurveyData($id);
 
@@ -109,7 +107,7 @@ class SurveysController extends AppController
             $survey = $this->Surveys->patchEntity($survey, $data, ['validate' => false]);
 
             if ($this->Surveys->save($survey)) {
-                $this->Flash->success(__('Survey was successfully saved.'));
+                $this->Flash->success((string)__('Survey was successfully saved.'));
 
                 $fullSurvey = $this->Surveys->getSurveyData($survey->id, true);
 
@@ -124,7 +122,7 @@ class SurveysController extends AppController
                 return $this->redirect(['action' => 'view', $id]);
             }
 
-            $this->Flash->error(__('Couldn\'t publish the survey'));
+            $this->Flash->error((string)__('Couldn\'t publish the survey'));
         }
 
         $this->set(compact('survey'));
@@ -134,10 +132,9 @@ class SurveysController extends AppController
      * Publish method
      *
      * @param string|null $id Survey id.
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
-    public function preview($id = null)
+    public function preview(string $id = null)
     {
         $saved = $data = [];
         $survey = $this->Surveys->getSurveyData($id, true);
@@ -147,7 +144,7 @@ class SurveysController extends AppController
             $user = $this->Auth->user();
             $requestData = $this->request->getData();
             if (empty($requestData['SurveyResults'])) {
-                $this->Flash->error(__('Please submit your survey answers'));
+                $this->Flash->error((string)__('Please submit your survey answers'));
 
                 return $this->redirect(['controller' => 'Surveys', 'action' => 'view', $id]);
             }
@@ -172,11 +169,11 @@ class SurveysController extends AppController
             });
 
             if (empty($failed)) {
-                $this->Flash->success(__('Saved questionnaire results'));
+                $this->Flash->success((string)__('Saved questionnaire results'));
 
                 return $this->redirect(['controller' => 'Surveys', 'action' => 'view', $id]);
             } else {
-                $this->Flash->success(__('Some errors took place during result savings'));
+                $this->Flash->success((string)__('Some errors took place during result savings'));
             }
         }
 
@@ -187,10 +184,9 @@ class SurveysController extends AppController
      * Publish method
      *
      * @param string|null $id Survey id.
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
-    public function duplicate($id = null)
+    public function duplicate(string $id = null)
     {
         $this->autoRender = false;
         $survey = $this->Surveys->getSurveyData($id);
@@ -206,17 +202,17 @@ class SurveysController extends AppController
                 // Fixing order from original survey if there were any order gaps.
                 $sorted = $this->Surveys->setSequentialOrder($duplicated);
 
-                $this->Flash->success(__('Survey was successfully duplicated'));
+                $this->Flash->success((string)__('Survey was successfully duplicated'));
 
                 return $this->redirect(['action' => 'view', $duplicated->id]);
             }
-            $this->Flash->error(__('Couldn\'t duplicate the survey data'));
+            $this->Flash->error((string)__('Couldn\'t duplicate the survey data'));
         }
     }
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -225,11 +221,11 @@ class SurveysController extends AppController
         if ($this->request->is('post')) {
             $survey = $this->Surveys->patchEntity($survey, $this->request->getData());
             if ($this->Surveys->save($survey)) {
-                $this->Flash->success(__('The survey has been saved.'));
+                $this->Flash->success((string)__('The survey has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The survey could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The survey could not be saved. Please, try again.'));
         }
         $this->set(compact('survey'));
     }
@@ -238,16 +234,15 @@ class SurveysController extends AppController
      * Edit method
      *
      * @param string|null $id Survey id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Network\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects on successful edit, renders view otherwise.
      */
-    public function edit($id = null)
+    public function edit(string $id = null)
     {
         $survey = $this->Surveys->getSurveyData($id);
         $redirect = ['controller' => 'Surveys', 'action' => 'view', $survey->id];
 
         if (!empty($survey->publish_date)) {
-            $this->Flash->error(__('You cannot edit alredy published survey'));
+            $this->Flash->error((string)__('You cannot edit alredy published survey'));
 
             return $this->redirect($redirect);
         }
@@ -255,11 +250,11 @@ class SurveysController extends AppController
         if ($this->request->is(['patch', 'post', 'put'])) {
             $survey = $this->Surveys->patchEntity($survey, $this->request->getData());
             if ($this->Surveys->save($survey)) {
-                $this->Flash->success(__('The survey has been saved.'));
+                $this->Flash->success((string)__('The survey has been saved.'));
 
                 return $this->redirect($redirect);
             }
-            $this->Flash->error(__('The survey could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The survey could not be saved. Please, try again.'));
         }
         $this->set(compact('survey'));
     }
@@ -268,17 +263,16 @@ class SurveysController extends AppController
      * Delete method
      *
      * @param string|null $id Survey id.
-     * @return \Cake\Http\Response|null Redirects to index.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects to index.
      */
-    public function delete($id = null)
+    public function delete(string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
         $survey = $this->Surveys->getSurveyData($id);
         if ($this->Surveys->delete($survey)) {
-            $this->Flash->success(__('The survey has been deleted.'));
+            $this->Flash->success((string)__('The survey has been deleted.'));
         } else {
-            $this->Flash->error(__('The survey could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The survey could not be deleted. Please, try again.'));
         }
 
         return $this->redirect(['action' => 'index']);
@@ -290,9 +284,9 @@ class SurveysController extends AppController
      * @param string $surveyId of the given survey
      * @param string $submitId of specific submission
      *
-     * @return \Cake\Network\Response
+     * @return \Cake\Network\Response|void|null
      */
-    public function viewSubmit($surveyId, $submitId)
+    public function viewSubmit(string $surveyId, string $submitId)
     {
         $this->SurveyQuestions = TableRegistry::get('Qobo/Survey.SurveyQuestions');
         $survey = $this->Surveys->getSurveyData($surveyId);

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -63,7 +63,7 @@ class SurveysController extends AppController
      * @param string|null $id Survey id.
      * @return \Cake\Http\Response|void|null
      */
-    public function view(string $id = null)
+    public function view(?string $id)
     {
         /**
          * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $table
@@ -152,10 +152,10 @@ class SurveysController extends AppController
     /**
      * Publish method
      *
-     * @param string|null $id Survey id.
+     * @param string $id Survey id.
      * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
-    public function preview(string $id = null)
+    public function preview(string $id)
     {
         $saved = $data = [];
         $survey = $this->Surveys->getSurveyData($id, true);
@@ -212,7 +212,7 @@ class SurveysController extends AppController
      * @param string|null $id Survey id.
      * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
-    public function duplicate(string $id = null)
+    public function duplicate(?string $id)
     {
         $this->autoRender = false;
         $survey = $this->Surveys->getSurveyData($id);
@@ -304,10 +304,10 @@ class SurveysController extends AppController
     /**
      * Delete method
      *
-     * @param string|null $id Survey id.
+     * @param string $id Survey id.
      * @return \Cake\Http\Response|void|null Redirects to index.
      */
-    public function delete(string $id = null)
+    public function delete(string $id)
     {
         $this->request->allowMethod(['post', 'delete']);
         $survey = $this->Surveys->getSurveyData($id);

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -74,7 +74,7 @@ class SurveysController extends AppController
             'data' => [],
         ]);
 
-        $this->eventManager()->dispatch($event);
+        $this->getEventManager()->dispatch($event);
 
         if (!empty($event->result)) {
             $submits = $event->result;
@@ -119,7 +119,7 @@ class SurveysController extends AppController
                         'survey' => $fullSurvey,
                     ]
                 ]);
-                $this->eventManager()->dispatch($event);
+                $this->getEventManager()->dispatch($event);
 
                 return $this->redirect(['action' => 'view', $id]);
             }
@@ -145,17 +145,18 @@ class SurveysController extends AppController
         if ($this->request->is(['post', 'put', 'patch'])) {
             $this->SurveyResults = TableRegistry::get('Qobo/Survey.SurveyResults');
             $user = $this->Auth->user();
-            if (empty($this->request->data['SurveyResults'])) {
+            $requestData = $this->request->getData();
+            if (empty($requestData['SurveyResults'])) {
                 $this->Flash->error(__('Please submit your survey answers'));
 
                 return $this->redirect(['controller' => 'Surveys', 'action' => 'view', $id]);
             }
 
-            foreach ($this->request->data['SurveyResults'] as $k => $item) {
+            foreach ($requestData['SurveyResults'] as $k => $item) {
                 $results = $this->SurveyResults->getResults($item, [
                     'user' => $user,
                     'survey' => $survey,
-                    'data' => $this->request->data
+                    'data' => $requestData
                 ]);
 
                 $data = array_merge($data, $results);

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -20,6 +20,8 @@ use Qobo\Survey\Event\EventName;
  * Surveys Controller
  *
  * @property \Qobo\Survey\Model\Table\SurveysTable $Surveys
+ * @property \Qobo\Survey\Model\Table\SurveyAnswersTable $SurveyAnswers
+ * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable $SurveyQuestions
  *
  * @method \Qobo\Survey\Model\Entity\Survey[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
@@ -61,8 +63,17 @@ class SurveysController extends AppController
      */
     public function view(string $id = null)
     {
-        $this->SurveyQuestions = TableRegistry::get('Qobo/Survey.SurveyQuestions');
-        $this->SurveyResults = TableRegistry::get('Qobo/Survey.SurveyResults');
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $table
+         */
+        $table = TableRegistry::get('Qobo/Survey.SurveyQuestions');
+        $this->SurveyQuestions = $table;
+
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyResultsTable $table
+         */
+        $table = TableRegistry::get('Qobo/Survey.SurveyResults');
+        $this->SurveyResults = $table;
 
         $questionTypes = $this->SurveyQuestions->getQuestionTypes();
         $survey = $this->Surveys->getSurveyData($id, true);
@@ -284,7 +295,7 @@ class SurveysController extends AppController
      * @param string $surveyId of the given survey
      * @param string $submitId of specific submission
      *
-     * @return \Cake\Network\Response|void|null
+     * @return \Cake\Http\Response|void|null
      */
     public function viewSubmit(string $surveyId, string $submitId)
     {

--- a/src/Model/Entity/Survey.php
+++ b/src/Model/Entity/Survey.php
@@ -17,10 +17,14 @@ use Cake\ORM\Entity;
  * Survey Entity
  *
  * @property string $id
+ * @property string $parent_id
  * @property string $name
+ * @property string $slug
  * @property string $version
  * @property string $description
  * @property bool $active
+ * @property \Cake\I18n\Time $publish_date
+ * @property \Cake\I18n\Time $expiry_date
  * @property \Cake\I18n\Time $created
  * @property \Cake\I18n\Time $modified
  * @property \Cake\I18n\Time $trashed

--- a/src/Model/Table/SurveyAnswersTable.php
+++ b/src/Model/Table/SurveyAnswersTable.php
@@ -20,7 +20,7 @@ use Cake\Validation\Validator;
  * SurveyAnswers Model
  *
  * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable|\Cake\ORM\Association\BelongsTo $SurveyQuestions
- * @property |\Cake\ORM\Association\HasMany $SurveyResults
+ * @property \Cake\ORM\Association\HasMany $SurveyResults
  *
  * @method \Qobo\Survey\Model\Entity\SurveyAnswer get($primaryKey, $options = [])
  * @method \Qobo\Survey\Model\Entity\SurveyAnswer newEntity($data = null, array $options = [])

--- a/src/Model/Table/SurveyAnswersTable.php
+++ b/src/Model/Table/SurveyAnswersTable.php
@@ -29,6 +29,7 @@ use Cake\Validation\Validator;
  * @method \Qobo\Survey\Model\Entity\SurveyAnswer patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \Qobo\Survey\Model\Entity\SurveyAnswer[] patchEntities($entities, array $data, array $options = [])
  * @method \Qobo\Survey\Model\Entity\SurveyAnswer findOrCreate($search, callable $callback = null, $options = [])
+ * @method \ADmad\Sequence\Model\Behavior\SequenceBehavior setOrder(array $records)
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */

--- a/src/Model/Table/SurveyAnswersTable.php
+++ b/src/Model/Table/SurveyAnswersTable.php
@@ -19,8 +19,8 @@ use Cake\Validation\Validator;
 /**
  * SurveyAnswers Model
  *
- * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable|\Cake\ORM\Association\BelongsTo $SurveyQuestions
- * @property \Cake\ORM\Association\HasMany $SurveyResults
+ * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable $SurveyQuestions
+ * @property \Qobo\Survey\Model\Table\SurveyResultsTable $SurveyResults
  *
  * @method \Qobo\Survey\Model\Entity\SurveyAnswer get($primaryKey, $options = [])
  * @method \Qobo\Survey\Model\Entity\SurveyAnswer newEntity($data = null, array $options = [])

--- a/src/Model/Table/SurveyQuestionsTable.php
+++ b/src/Model/Table/SurveyQuestionsTable.php
@@ -20,8 +20,8 @@ use Cake\Validation\Validator;
  * SurveyQuestions Model
  *
  * @property \Qobo\Survey\Model\Table\SurveysTable|\Cake\ORM\Association\BelongsTo $Surveys
- * @property |\Cake\ORM\Association\HasMany $SurveyAnswers
- * @property |\Cake\ORM\Association\HasMany $SurveyResults
+ * @property \Cake\ORM\Association\HasMany $SurveyAnswers
+ * @property \Cake\ORM\Association\HasMany $SurveyResults
  *
  * @method \Qobo\Survey\Model\Entity\SurveyQuestion get($primaryKey, $options = [])
  * @method \Qobo\Survey\Model\Entity\SurveyQuestion newEntity($data = null, array $options = [])
@@ -124,9 +124,9 @@ class SurveyQuestionsTable extends Table
     /**
      * Get defined list of Question types currently available
      *
-     * @return array $list of question types.
+     * @return mixed[] $list of question types.
      */
-    public function getQuestionTypes()
+    public function getQuestionTypes(): array
     {
         return [
             'input' => 'Short Text or Number',

--- a/src/Model/Table/SurveyQuestionsTable.php
+++ b/src/Model/Table/SurveyQuestionsTable.php
@@ -30,6 +30,7 @@ use Cake\Validation\Validator;
  * @method \Qobo\Survey\Model\Entity\SurveyQuestion patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \Qobo\Survey\Model\Entity\SurveyQuestion[] patchEntities($entities, array $data, array $options = [])
  * @method \Qobo\Survey\Model\Entity\SurveyQuestion findOrCreate($search, callable $callback = null, $options = [])
+ * @method \ADmad\Sequence\Model\Behavior\SequenceBehavior setOrder(array $records)
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */

--- a/src/Model/Table/SurveyResultsTable.php
+++ b/src/Model/Table/SurveyResultsTable.php
@@ -81,7 +81,7 @@ class SurveyResultsTable extends Table
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator): \Cake\Validation\Validator
+    public function validationDefault(Validator $validator): Validator
     {
         $validator
             ->uuid('id')
@@ -106,7 +106,7 @@ class SurveyResultsTable extends Table
      * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
      * @return \Cake\ORM\RulesChecker
      */
-    public function buildRules(RulesChecker $rules): \Cake\ORM\RulesChecker
+    public function buildRules(RulesChecker $rules): RulesChecker
     {
         $rules->add($rules->existsIn(['survey_id'], 'Surveys'));
         $rules->add($rules->existsIn(['survey_question_id'], 'SurveyQuestions'));

--- a/src/Model/Table/SurveyResultsTable.php
+++ b/src/Model/Table/SurveyResultsTable.php
@@ -21,7 +21,7 @@ use Cake\Validation\Validator;
  *
  * @property \Qobo\Survey\Model\Table\SurveysTable|\Cake\ORM\Association\BelongsTo $Surveys
  * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable|\Cake\ORM\Association\BelongsTo $SurveyQuestions
- * @property |\Cake\ORM\Association\BelongsTo $SurveyAnswers
+ * @property \Cake\ORM\Association\BelongsTo $SurveyAnswers
  * @property \Qobo\Survey\Model\Table\UsersTable|\Cake\ORM\Association\BelongsTo $Users
  *
  * @method \Qobo\Survey\Model\Entity\SurveyResult get($primaryKey, $options = [])
@@ -40,10 +40,10 @@ class SurveyResultsTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param mixed[] $config The configuration for the Table.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         parent::initialize($config);
 
@@ -81,7 +81,7 @@ class SurveyResultsTable extends Table
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator)
+    public function validationDefault(Validator $validator): \Cake\Validation\Validator
     {
         $validator
             ->uuid('id')
@@ -106,7 +106,7 @@ class SurveyResultsTable extends Table
      * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
      * @return \Cake\ORM\RulesChecker
      */
-    public function buildRules(RulesChecker $rules)
+    public function buildRules(RulesChecker $rules): \Cake\ORM\RulesChecker
     {
         $rules->add($rules->existsIn(['survey_id'], 'Surveys'));
         $rules->add($rules->existsIn(['survey_question_id'], 'SurveyQuestions'));
@@ -121,12 +121,12 @@ class SurveyResultsTable extends Table
      * multiple answers, thus we create indexed array of those
      * records for later saving in DB table.
      *
-     * @param array $data containing SurveyResults request data item
-     * @param array $options containing user and survey instances
+     * @param mixed[] $data containing SurveyResults request data item
+     * @param mixed[] $options containing user and survey instances
      *
-     * @return array $result containing flat indexed array of all results.
+     * @return mixed[] $result containing flat indexed array of all results.
      */
-    public function getResults(array $data = [], array $options = [])
+    public function getResults(array $data = [], array $options = []): array
     {
         $result = [];
 
@@ -161,10 +161,10 @@ class SurveyResultsTable extends Table
     /**
      * Saving Survey Results
      *
-     * @param array $data containing results info
-     * @return array $result containing save status
+     * @param mixed[] $data containing results info
+     * @return mixed[] $result containing save status
      */
-    public function saveData(array $data = [])
+    public function saveData(array $data = []): array
     {
         $result = [
             'status' => false,
@@ -191,11 +191,11 @@ class SurveyResultsTable extends Table
      * Get Survey Results group by submit_id
      *
      * @param string $surveyId with primary key
-     * @param array $options with extra configs
+     * @param mixed[] $options with extra configs
      *
-     * @return \Cake\ORM\Query|null $result with submits
+     * @return \Cake\Datasource\ResultSetInterface|null $result with submits
      */
-    public function getSubmits($surveyId = null, array $options = [])
+    public function getSubmits(string $surveyId = null, array $options = []): ?\Cake\Datasource\ResultSetInterface
     {
         $result = null;
 

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -80,7 +80,7 @@ class SurveysTable extends Table
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator): \Cake\Validation\Validator
+    public function validationDefault(Validator $validator): Validator
     {
         $validator
             ->uuid('id')
@@ -122,7 +122,7 @@ class SurveysTable extends Table
      * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
      * @return \Cake\ORM\RulesChecker
      */
-    public function buildRules(RulesChecker $rules): \Cake\ORM\RulesChecker
+    public function buildRules(RulesChecker $rules): RulesChecker
     {
         $rules->add($rules->isUnique(['slug']));
 

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -33,6 +33,8 @@ use Cake\Validation\Validator;
  * @method \Qobo\Survey\Model\Entity\Survey findOrCreate($search, callable $callback = null, $options = [])
  * @method \Duplicatable\Model\Behavior\DuplicatableBehavior duplicate($id)
  * @method \ADmad\Sequence\Model\Behavior\SequenceBehavior setOrder(array $records)
+ * @method \ADmad\Sequence\Model\Behavior\SequenceBehavior moveUp($entity)
+ * @method \ADmad\Sequence\Model\Behavior\SequenceBehavior moveDown($entity)
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -159,8 +159,12 @@ class SurveysTable extends Table
 
         $query = $this->find('all');
         $query->limit(1);
-        $query->where(['Surveys.id' => $surveyId]);
-        $query->orWhere(['Surveys.slug' => $surveyId]);
+        $query->where([
+            'OR' => [
+                'Surveys.id' => $surveyId,
+                'Surveys.slug' => $surveyId
+            ]
+        ]);
         if ($contain) {
             $query->contain(['SurveyQuestions' => [
                 'sort' => ['SurveyQuestions.order' => 'ASC'],

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -39,10 +39,10 @@ class SurveysTable extends Table
     /**
      * Initialize method
      *
-     * @param array $config The configuration for the Table.
+     * @param mixed[] $config The configuration for the Table.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         parent::initialize($config);
 
@@ -75,7 +75,7 @@ class SurveysTable extends Table
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator)
+    public function validationDefault(Validator $validator): \Cake\Validation\Validator
     {
         $validator
             ->uuid('id')
@@ -117,7 +117,7 @@ class SurveysTable extends Table
      * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
      * @return \Cake\ORM\RulesChecker
      */
-    public function buildRules(RulesChecker $rules)
+    public function buildRules(RulesChecker $rules): \Cake\ORM\RulesChecker
     {
         $rules->add($rules->isUnique(['slug']));
 
@@ -127,9 +127,9 @@ class SurveysTable extends Table
     /**
      * Get Survey Categories
      *
-     * @return array $result list of categories.
+     * @return mixed[] $result list of categories.
      */
-    public function getSurveyCategories()
+    public function getSurveyCategories(): array
     {
         $result = [];
         $config = Configure::read('Survey.Categories');
@@ -147,9 +147,9 @@ class SurveysTable extends Table
      * @param string|null $surveyId for the record
      * @param bool $contain to attach containable Q&A entities or not.
      *
-     * @return array $result containing the survey's data.
+     * @return mixed[] $result containing the survey's data.
      */
-    public function getSurveyData($surveyId = null, $contain = false)
+    public function getSurveyData(string $surveyId = null, bool $contain = false)
     {
         $result = [];
 
@@ -192,11 +192,11 @@ class SurveysTable extends Table
      * We make sure the user didn't forget to add at least
      * one answer option to survey question
      *
-     * @param mixed $id of the survey or its slug
+     * @param string $id of the survey or its slug
      * @param \Cake\Network\Request $request object from controller
      * @return array $response with status flag and possible errors
      */
-    public function prepublishValidate($id, $request = null)
+    public function prepublishValidate(string $id, $request = null)
     {
         $response = [
             'status' => false,
@@ -238,10 +238,17 @@ class SurveysTable extends Table
      * @param \Cake\Datasource\EntityInterface $entity of the survey
      * @return bool $sorted for sorting result
      */
-    public function setSequentialOrder(EntityInterface $entity)
+    public function setSequentialOrder(EntityInterface $entity): bool
     {
         $sorted = false;
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $questions
+         */
         $questions = TableRegistry::get('Qobo/Survey.SurveyQuestions');
+
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyAnswersTable $answers
+         */
         $answers = TableRegistry::get('Qobo/Survey.SurveyAnswers');
 
         $query = $questions->find()

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -193,7 +193,7 @@ class SurveysTable extends Table
      * one answer option to survey question
      *
      * @param string $id of the survey or its slug
-     * @param \Cake\Network\Request $request object from controller
+     * @param \Cake\Http\Request $request object from controller
      * @return array $response with status flag and possible errors
      */
     public function prepublishValidate(string $id, $request = null)

--- a/src/Template/SurveyAnswers/add.ctp
+++ b/src/Template/SurveyAnswers/add.ctp
@@ -33,10 +33,10 @@ $options['title'] .= __('Create {0}', ['Question Option']);
         <div class="box-body">
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?= $this->Form->input('answer') ?>
-                    <?= $this->Form->input('comment') ?>
-                    <?= $this->Form->input('score') ?>
-                    <?= $this->Form->input('order') ?>
+                    <?= $this->Form->control('answer') ?>
+                    <?= $this->Form->control('comment') ?>
+                    <?= $this->Form->control('score') ?>
+                    <?= $this->Form->control('order') ?>
                 </div>
             </div>
         <?= $this->Form->button(__('Submit')) ?>

--- a/src/Template/SurveyAnswers/edit.ctp
+++ b/src/Template/SurveyAnswers/edit.ctp
@@ -33,10 +33,10 @@ $options['title'] .= __('Edit "{0}"', [$surveyAnswer->answer]);
         <div class="box-body">
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?= $this->Form->input('answer') ?>
-                    <?= $this->Form->input('comment') ?>
-                    <?= $this->Form->input('score') ?>
-                    <?= $this->Form->input('order') ?>
+                    <?= $this->Form->control('answer') ?>
+                    <?= $this->Form->control('comment') ?>
+                    <?= $this->Form->control('score') ?>
+                    <?= $this->Form->control('order') ?>
                 </div>
             </div>
         <?= $this->Form->button(__('Submit')) ?>

--- a/src/Template/SurveyQuestions/add.ctp
+++ b/src/Template/SurveyQuestions/add.ctp
@@ -35,7 +35,7 @@ $options['title'] .= __('Add {0}', ['Survey Question']);
         <div class="box-body">
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('question', ['type' => 'text']); ?>
+                    <?php echo $this->Form->control('question', ['type' => 'text']); ?>
                 </div>
             </div>
             <div class="row">
@@ -46,17 +46,17 @@ $options['title'] .= __('Add {0}', ['Survey Question']);
             </div>
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('active', ['checked' => true]); ?>
+                    <?php echo $this->Form->control('active', ['checked' => true]); ?>
                 </div>
             </div>
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('type', ['options' => $questionTypes]); ?>
+                    <?php echo $this->Form->control('type', ['options' => $questionTypes]); ?>
                 </div>
             </div>
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('order');?>
+                    <?php echo $this->Form->control('order');?>
                 </div>
             </div>
 

--- a/src/Template/SurveyQuestions/edit.ctp
+++ b/src/Template/SurveyQuestions/edit.ctp
@@ -37,7 +37,7 @@ $options['title'] .= $this->Html->link(
         <div class="box-body">
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('question', ['type' => 'text']); ?>
+                    <?php echo $this->Form->control('question', ['type' => 'text']); ?>
                 </div>
             </div>
             <div class="row">
@@ -48,17 +48,17 @@ $options['title'] .= $this->Html->link(
             </div>
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('active'); ?>
+                    <?php echo $this->Form->control('active'); ?>
                 </div>
             </div>
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('type', ['options' => $questionTypes]); ?>
+                    <?php echo $this->Form->control('type', ['options' => $questionTypes]); ?>
                 </div>
             </div>
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('order');?>
+                    <?php echo $this->Form->control('order');?>
                 </div>
             </div>
 

--- a/src/Template/Surveys/add.ctp
+++ b/src/Template/Surveys/add.ctp
@@ -33,18 +33,18 @@ echo $this->Html->script([
         <div class="box-body">
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('name'); ?>
+                    <?php echo $this->Form->control('name'); ?>
                 </div>
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('category', ['options' => $categories]); ?>
+                    <?php echo $this->Form->control('category', ['options' => $categories]); ?>
                 </div>
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('description');?>
+                    <?php echo $this->Form->control('description');?>
                 </div>
                 <div class="col-xs-12 col-md-6">
                     <?php
                     $label = $this->Form->label('active');
-                    echo $this->Form->input('active', [
+                    echo $this->Form->control('active', [
                         'type' => 'checkbox',
                         'checked' => $checked,
                         'class' => 'square',

--- a/src/Template/Surveys/edit.ctp
+++ b/src/Template/Surveys/edit.ctp
@@ -33,18 +33,18 @@ echo $this->Html->script([
         <div class="box-body">
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('name'); ?>
+                    <?php echo $this->Form->control('name'); ?>
                 </div>
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('category', ['options' => $categories]); ?>
+                    <?php echo $this->Form->control('category', ['options' => $categories]); ?>
                 </div>
                 <div class="col-xs-12 col-md-6">
-                    <?php echo $this->Form->input('description');?>
+                    <?php echo $this->Form->control('description');?>
                 </div>
                 <div class="col-xs-12 col-md-6">
                     <?php
                     $label = $this->Form->label('active');
-                    echo $this->Form->input('active', [
+                    echo $this->Form->control('active', [
                         'type' => 'checkbox',
                         'checked' => $checked,
                         'class' => 'square',

--- a/src/Template/Surveys/publish.ctp
+++ b/src/Template/Surveys/publish.ctp
@@ -34,7 +34,7 @@ echo $this->Html->script([
         <div class="box-body">
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?= $this->Form->input('Surveys.publish_date', [
+                    <?= $this->Form->control('Surveys.publish_date', [
                         'type' => 'text',
                         'class' => 'form-control',
                         'data-provide' => 'datetimepicker',
@@ -53,7 +53,7 @@ echo $this->Html->script([
             </div>
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?= $this->Form->input('Surveys.expiry_date', [
+                    <?= $this->Form->control('Surveys.expiry_date', [
                         'type' => 'text',
                         'class' => 'form-control',
                         'data-provide' => 'datetimepicker',

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @since     3.3.0
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Survey\Test\App;
+
+use Cake\Core\Configure;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\AssetMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
+ */
+class Application extends BaseApplication
+{
+    /**
+     * Setup the middleware queue your application will use.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
+     * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
+     */
+    public function middleware($middlewareQueue)
+    {
+        $middlewareQueue
+            // Catch any exceptions in the lower layers,
+            // and make an error page/response
+            ->add(ErrorHandlerMiddleware::class)
+
+            // Handle plugin/theme assets like CakePHP normally does.
+            ->add(AssetMiddleware::class)
+
+            // Add routing middleware.
+            ->add(new RoutingMiddleware($this));
+
+        return $middlewareQueue;
+    }
+}

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -5,5 +5,16 @@ use \Cake\Controller\Controller;
 
 class AppController extends Controller
 {
-    public $components = ['Auth', 'Flash', 'RequestHandler'];
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('Auth', [
+            'authenticate' => ['Form']
+        ]);
+
+        $this->loadComponent('Flash');
+        $this->loadComponent('RequestHandler', [
+            'enableBeforeRedirect' => false,
+        ]);
+    }
 }

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -1,14 +1,16 @@
 <?php
 namespace Qobo\Survey\Test\App\Controller;
 
-use \Cake\Controller\Controller;
+use Cake\Controller\Controller;
 
 class UsersController extends Controller
 {
     /**
      * Simple users login action
+     *
+     * @return void
      */
-    public function login()
+    public function login(): void
     {
     }
 }

--- a/tests/TestCase/Controller/SurveyAnswersControllerTest.php
+++ b/tests/TestCase/Controller/SurveyAnswersControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Qobo\Survey\Test\TestCase\Controller;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
 use Qobo\Survey\Controller\SurveysController;
@@ -57,18 +58,27 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
     public function testViewOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $survey = $this->Surveys->getSurveyData($surveyId);
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $question = $query->first();
 
         $query = $this->SurveyAnswers->find()
-            ->where(['survey_question_id' => $question->id]);
+            ->where(['survey_question_id' => $question->get('id')]);
 
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $answer = $query->first();
 
-        $url = '/surveys/survey/' . $survey->slug . '/answers/view/' . $question->id . '/' . $answer->id;
+        $url = '/surveys/survey/' . $survey->get('slug') . '/answers/view/' . $question->get('id') . '/' . $answer->get('id');
         $this->get($url);
         $this->assertResponseOk();
     }
@@ -76,13 +86,20 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
     public function testAddGetOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $survey = $this->Surveys->getSurveyData($surveyId);
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
+
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $question = $query->first();
 
-        $url = '/surveys/survey/' . $survey->slug . '/answers/add/' . $question->id;
+        $url = '/surveys/survey/' . $survey->get('slug') . '/answers/add/' . $question->get('id');
         $this->get($url);
         $this->assertResponseOk();
     }
@@ -90,18 +107,28 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
     public function testEditGetOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $survey = $this->Surveys->getSurveyData($surveyId);
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
+
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $question = $query->first();
 
         $query = $this->SurveyAnswers->find()
-            ->where(['survey_question_id' => $question->id]);
+            ->where(['survey_question_id' => $question->get('id')]);
 
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $answer = $query->first();
 
-        $url = '/surveys/survey/' . $survey->slug . '/answers/edit/' . $question->id . '/' . $answer->id;
+        $url = '/surveys/survey/' . $survey->get('slug') . '/answers/edit/' . $question->get('id') . '/' . $answer->get('id');
         $this->get($url);
         $this->assertResponseOk();
     }
@@ -109,67 +136,95 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
     public function testDeleteOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $survey = $this->Surveys->getSurveyData($surveyId);
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $question = $query->first();
 
         $query = $this->SurveyAnswers->find()
-            ->where(['survey_question_id' => $question->id]);
-
+            ->where(['survey_question_id' => $question->get('id')]);
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $answer = $query->first();
 
-        $url = '/surveys/survey/' . $survey->slug . '/answers/delete/' . $question->id . '/' . $answer->id;
+        $url = '/surveys/survey/' . $survey->get('slug') . '/answers/delete/' . $question->get('id') . '/' . $answer->get('id');
         $this->delete($url);
-        $redirect = ['controller' => 'SurveyQuestions', 'action' => 'view', $survey->slug, $question->id];
+        $redirect = ['controller' => 'SurveyQuestions', 'action' => 'view', $survey->get('slug'), $question->get('id')];
         $this->assertRedirect($redirect);
     }
 
     public function testAddPostOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $survey = $this->Surveys->getSurveyData($surveyId);
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $question = $query->first();
 
         $postData = [
             'answer' => 'Whaat',
-            'survey_question_id' => $question->id,
+            'survey_question_id' => $question->get('id'),
             'score' => 999,
             'order' => 5,
         ];
 
         $this->post(
-            '/surveys/survey/' . $survey->slug . '/answers/add/' . $question->id,
+            '/surveys/survey/' . $survey->get('slug') . '/answers/add/' . $question->get('id'),
             $postData
         );
 
         $query = $this->SurveyAnswers->find()
             ->where(['score' => $postData['score']]);
 
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $saved = $query->first();
-        $this->assertRedirect(['controller' => 'SurveyQuestions', 'action' => 'view', $survey->slug, $question->id]);
-        $this->assertEquals($saved->order, $postData['order']);
-        $this->assertEquals($saved->answer, $postData['answer']);
+
+        $this->assertRedirect(['controller' => 'SurveyQuestions', 'action' => 'view', $survey->get('slug'), $question->get('id')]);
+        $this->assertEquals($saved->get('order'), $postData['order']);
+        $this->assertEquals($saved->get('answer'), $postData['answer']);
     }
 
     public function testEditPostOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
+
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $survey = $this->Surveys->getSurveyData($surveyId);
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $question = $query->first();
 
         $query = $this->SurveyAnswers->find()
-            ->where(['survey_question_id' => $question->id]);
+            ->where(['survey_question_id' => $question->get('id')]);
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $answer = $query->first();
 
-        $url = '/surveys/survey/' . $survey->slug . '/answers/edit/' . $question->id . '/' . $answer->id;
+        $url = '/surveys/survey/' . $survey->get('slug') . '/answers/edit/' . $question->get('id') . '/' . $answer->get('id');
 
         $editData = [
             'answer' => 'Doctor Who?',
@@ -177,14 +232,16 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
 
         $this->post($url, $editData);
 
-        $this->assertRedirect(['controller' => 'SurveyQuestions', 'action' => 'view', $survey->slug, $question->id]);
+        $this->assertRedirect(['controller' => 'SurveyQuestions', 'action' => 'view', $survey->get('slug'), $question->get('id')]);
 
         $query = $this->SurveyAnswers->find()
-            ->where(['id' => $answer->id]);
-
+            ->where(['id' => $answer->get('id')]);
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $edited = $query->first();
 
-        $this->assertEquals($edited->answer, $editData['answer']);
-        $this->assertEquals($edited->id, $answer->id);
+        $this->assertEquals($edited->get('answer'), $editData['answer']);
+        $this->assertEquals($edited->get('id'), $answer->get('id'));
     }
 }

--- a/tests/TestCase/Controller/SurveyAnswersControllerTest.php
+++ b/tests/TestCase/Controller/SurveyAnswersControllerTest.php
@@ -35,7 +35,7 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
         $this->SurveyAnswers = TableRegistry::get('SurveyAnswers', ['className' => SurveyAnswersTable::class]);
     }
 
-    public function testViewOk()
+    public function testViewOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -54,7 +54,7 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testAddGetOk()
+    public function testAddGetOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -68,7 +68,7 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testEditGetOk()
+    public function testEditGetOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -87,7 +87,7 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testDeleteOk()
+    public function testDeleteOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -107,7 +107,7 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
         $this->assertRedirect($redirect);
     }
 
-    public function testAddPostOk()
+    public function testAddPostOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -137,7 +137,7 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
         $this->assertEquals($saved->answer, $postData['answer']);
     }
 
-    public function testEditPostOk()
+    public function testEditPostOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);

--- a/tests/TestCase/Controller/SurveyAnswersControllerTest.php
+++ b/tests/TestCase/Controller/SurveyAnswersControllerTest.php
@@ -8,6 +8,11 @@ use Qobo\Survey\Model\Table\SurveyAnswersTable;
 use Qobo\Survey\Model\Table\SurveyQuestionsTable;
 use Qobo\Survey\Model\Table\SurveysTable;
 
+/**
+ * @property \Qobo\Survey\Model\Table\SurveysTable $Surveys
+ * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable $SurveyQuestions
+ * @property \Qobo\Survey\Model\Table\SurveyAnswersTable $SurveyAnswers
+ */
 class SurveyAnswersControllerTest extends IntegrationTestCase
 {
 
@@ -30,9 +35,23 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
             ]
         ]);
 
-        $this->Surveys = TableRegistry::get('Surveys', ['className' => SurveysTable::class]);
-        $this->SurveyQuestions = TableRegistry::get('SurveyQuestions', ['className' => SurveyQuestionsTable::class]);
-        $this->SurveyAnswers = TableRegistry::get('SurveyAnswers', ['className' => SurveyAnswersTable::class]);
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveysTable $table
+         */
+        $table = TableRegistry::get('Surveys', ['className' => SurveysTable::class]);
+        $this->Surveys = $table;
+
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $table
+         */
+        $table = TableRegistry::get('SurveyQuestions', ['className' => SurveyQuestionsTable::class]);
+        $this->SurveyQuestions = $table;
+
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyAnswersTable $table
+         */
+        $table = TableRegistry::get('SurveyAnswers', ['className' => SurveyAnswersTable::class]);
+        $this->SurveyAnswers = $table;
     }
 
     public function testViewOk(): void

--- a/tests/TestCase/Controller/SurveyQuestionsControllerTest.php
+++ b/tests/TestCase/Controller/SurveyQuestionsControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Qobo\Survey\Test\TestCase\Controller;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
 use Qobo\Survey\Controller\SurveysController;
@@ -57,14 +58,26 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
 
-        $slug = $survey->slug;
+        if (! $survey instanceof EntityInterface || is_null($survey)) {
+            $this->fail("Survey is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $slug = $survey->get('slug');
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
 
         $question = $query->first();
 
-        $this->get('/surveys/survey/' . $survey->slug . '/questions/view/' . $question->id);
+        if (! $question instanceof EntityInterface) {
+            $this->fail("Question query result is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $this->get('/surveys/survey/' . $survey->get('slug') . '/questions/view/' . $question->get('id'));
         $this->assertResponseOk();
     }
 
@@ -73,13 +86,26 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
 
-        $slug = $survey->slug;
+        if (! $survey instanceof EntityInterface || is_null($survey)) {
+            $this->fail("Survey is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $slug = $survey->get('slug');
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
 
         $question = $query->first();
-        $url = '/surveys/survey/' . $survey->slug . '/questions/preview/' . $question->id;
+
+        if (! $question instanceof EntityInterface) {
+            $this->fail("Question is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $url = '/surveys/survey/' . $survey->get('slug') . '/questions/preview/' . $question->get('id');
 
         $this->get($url);
         $this->assertResponseOk();
@@ -93,8 +119,14 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
 
-        $slug = $survey->slug;
-        $url = '/surveys/survey/' . $survey->slug . '/questions/add';
+        if (! $survey instanceof EntityInterface || is_null($survey)) {
+            $this->fail("Survey is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $slug = $survey->get('slug');
+        $url = '/surveys/survey/' . $slug . '/questions/add';
 
         $this->get($url);
         $this->assertResponseOk();
@@ -105,13 +137,26 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
 
-        $slug = $survey->slug;
+        if (! $survey instanceof EntityInterface) {
+            $this->fail("EntityInterface is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $slug = $survey->get('slug');
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
 
         $question = $query->first();
-        $url = '/surveys/survey/' . $survey->slug . '/questions/edit/' . $question->id;
+
+        if (! $question instanceof EntityInterface) {
+            $this->fail("Question is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $url = '/surveys/survey/' . $slug . '/questions/edit/' . $question->get('id');
 
         $this->get($url);
         $this->assertResponseOk();
@@ -122,16 +167,28 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
 
-        $slug = $survey->slug;
+        if (! $survey instanceof EntityInterface) {
+            $this->fail("Survey is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $slug = $survey->get('slug');
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
 
         $question = $query->first();
-        $url = '/surveys/survey/' . $survey->slug . '/questions/delete/' . $question->id;
 
+        if (! $question instanceof EntityInterface) {
+            $this->fail("Question is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $url = '/surveys/survey/' . $slug . '/questions/delete/' . $question->get('id');
         $this->delete($url);
-        $this->assertRedirect(['controller' => 'Surveys', 'action' => 'view', $survey->slug]);
+        $this->assertRedirect(['controller' => 'Surveys', 'action' => 'view', $slug]);
     }
 
     /**
@@ -142,13 +199,26 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
 
-        $slug = $survey->slug;
+        if (! $survey instanceof EntityInterface || is_null($survey)) {
+            $this->fail("Survey is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $slug = $survey->get('slug');
 
         $query = $this->SurveyQuestions->find()
-            ->where(['survey_id' => $survey->id]);
+            ->where(['survey_id' => $survey->get('id')]);
 
         $question = $query->first();
-        $url = '/surveys/survey/' . $survey->slug . '/questions/delete/' . $question->id;
+
+        if (! $question instanceof EntityInterface) {
+            $this->fail("Question is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $url = '/surveys/survey/' . $slug . '/questions/delete/' . $question->get('id');
 
         $fakeUrl = $url . '-fake';
         $this->delete($fakeUrl);
@@ -159,23 +229,36 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
-        $slug = $survey->slug;
+
+        if (! $survey instanceof EntityInterface) {
+            $this->fail("Survey is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+        $slug = $survey->get('slug');
 
         $postData = [
-            'survey_id' => $survey->id,
+            'survey_id' => $survey->get('id'),
             'question' => 'Who are you?',
             'type' => 'checkbox',
             'order' => 1
         ];
 
-        $this->post('/surveys/survey/' . $survey->slug . '/questions/add', $postData);
+        $this->post('/surveys/survey/' . $slug . '/questions/add', $postData);
         $query = $this->SurveyQuestions->find()
             ->where(['question' => $postData['question']]);
 
         $question = $query->first();
-        $this->assertRedirect(['controller' => 'SurveyAnswers', 'action' => 'add', $survey->slug, $question->id]);
-        $this->assertEquals($question->question, $postData['question']);
-        $this->assertEquals($question->type, $postData['type']);
+
+        if (! $question instanceof EntityInterface) {
+            $this->fail("Question is not of type EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+
+        $this->assertRedirect(['controller' => 'SurveyAnswers', 'action' => 'add', $survey->get('slug'), $question->get('id')]);
+        $this->assertEquals($question->get('question'), $postData['question']);
+        $this->assertEquals($question->get('type'), $postData['type']);
     }
 
     public function testEditPostOk(): void
@@ -183,13 +266,19 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $questionId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
-        $slug = $survey->slug;
+
+        if (! $survey instanceof EntityInterface) {
+            $this->fail("Survey is not of EntityInterface type: " . __METHOD__);
+
+            return;
+        }
+        $slug = $survey->get('slug');
 
         $editData = [
             'question' => 'Who are they?',
         ];
 
-        $this->post('/surveys/survey/' . $survey->slug . '/questions/edit/' . $questionId, $editData);
+        $this->post('/surveys/survey/' . $slug . '/questions/edit/' . $questionId, $editData);
 
         $query = $this->SurveyQuestions->find()
             ->where(['id' => $questionId]);
@@ -199,7 +288,7 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
          */
         $editedQuestion = $query->first();
 
-        $this->assertRedirect(['controller' => 'SurveyQuestions', 'action' => 'view', $survey->slug, $editedQuestion->id]);
+        $this->assertRedirect(['controller' => 'SurveyQuestions', 'action' => 'view', $slug, $editedQuestion->get('id')]);
         $this->assertEquals($editedQuestion->question, $editData['question']);
         $this->assertEquals($editedQuestion->id, $questionId);
     }

--- a/tests/TestCase/Controller/SurveyQuestionsControllerTest.php
+++ b/tests/TestCase/Controller/SurveyQuestionsControllerTest.php
@@ -18,6 +18,16 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         'plugin.qobo/survey.users',
     ];
 
+    /**
+     * @var \Qobo\Survey\Model\Table\SurveysTable $Surveys
+     */
+    public $Surveys;
+
+    /**
+     * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $SurveyQuestions
+     */
+    public $SurveyQuestions;
+
     public function setUp()
     {
         parent::setUp();
@@ -28,11 +38,21 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
                 'User' => TableRegistry::get('Users')->get($userId)->toArray()
             ]
         ]);
-        $this->Surveys = TableRegistry::get('Surveys', ['className' => SurveysTable::class]);
-        $this->SurveyQuestions = TableRegistry::get('SurveyQuestions', ['className' => SurveyQuestionsTable::class]);
+
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveysTable $table
+         */
+        $table = TableRegistry::get('Survey.Surveys', ['className' => SurveysTable::class]);
+        $this->Surveys = $table;
+
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $table
+         */
+        $table = TableRegistry::get('Survey.SurveyQuestions', ['className' => SurveyQuestionsTable::class]);
+        $this->SurveyQuestions = $table;
     }
 
-    public function testViewOk()
+    public function testViewOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -48,7 +68,7 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testPreviewOk()
+    public function testPreviewOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -68,7 +88,7 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testAddOk()
+    public function testAddOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -80,7 +100,7 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testEditOk()
+    public function testEditOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -97,7 +117,7 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testDeleteOk()
+    public function testDeleteOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -117,7 +137,7 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
     /**
      * \Cake\Datasource\Exception\RecordNotFoundException
      */
-    public function testDeleteFailed()
+    public function testDeleteFailed(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -135,7 +155,7 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(404);
     }
 
-    public function testAddPostOk()
+    public function testAddPostOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $survey = $this->Surveys->getSurveyData($surveyId);
@@ -158,7 +178,7 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $this->assertEquals($question->type, $postData['type']);
     }
 
-    public function testEditPostOk()
+    public function testEditPostOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $questionId = '00000000-0000-0000-0000-000000000001';
@@ -174,6 +194,9 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $query = $this->SurveyQuestions->find()
             ->where(['id' => $questionId]);
 
+        /**
+         * @var \Qobo\Survey\Model\Entity\SurveyQuestion $editedQuestion
+         */
         $editedQuestion = $query->first();
 
         $this->assertRedirect(['controller' => 'SurveyQuestions', 'action' => 'view', $survey->slug, $editedQuestion->id]);

--- a/tests/TestCase/Controller/SurveysControllerTest.php
+++ b/tests/TestCase/Controller/SurveysControllerTest.php
@@ -18,6 +18,16 @@ class SurveysControllerTest extends IntegrationTestCase
         'plugin.qobo/survey.users',
     ];
 
+    /**
+     * @var \Qobo\Survey\Model\Table\SurveysTable
+     */
+    public $Surveys;
+
+    /**
+     * @var \Qobo\Survey\Model\Table\SurveyResultsTable
+     */
+    public $SurveyResults;
+
     public function setUp()
     {
         parent::setUp();
@@ -29,8 +39,17 @@ class SurveysControllerTest extends IntegrationTestCase
             ]
         ]);
 
-        $this->Surveys = TableRegistry::get('Surveys', ['className' => SurveysTable::class]);
-        $this->SurveyResults = TableRegistry::get('SurveyResults', ['className' => SurveyResultsTable::class]);
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveysTable $table
+         */
+        $table = TableRegistry::get('Survey.Surveys', ['className' => SurveysTable::class]);
+        $this->Surveys = $table;
+
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyResultsTable $table
+         */
+        $table = TableRegistry::get('Survey.SurveyResults', ['className' => SurveyResultsTable::class]);
+        $this->SurveyResults = $table;
     }
 
     public function tearDown()
@@ -39,54 +58,54 @@ class SurveysControllerTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function testIndex()
+    public function testIndex(): void
     {
         $this->get('/surveys/surveys');
         $this->assertResponseOk();
     }
 
-    public function testAdd()
+    public function testAdd(): void
     {
         $this->get('/surveys/surveys/add');
         $this->assertResponseOk();
     }
 
-    public function testEdit()
+    public function testEdit(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $this->get('/surveys/surveys/edit/' . $surveyId);
         $this->assertResponseOk();
     }
 
-    public function testViewOk()
+    public function testViewOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $this->get('/surveys/surveys/view/' . $surveyId);
         $this->assertResponseOk();
     }
 
-    public function testPublishOk()
+    public function testPublishOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $this->get('/surveys/surveys/publish/' . $surveyId);
         $this->assertResponseOk();
     }
 
-    public function testDuplicateOk()
+    public function testDuplicateOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $this->get('/surveys/surveys/duplicate/' . $surveyId);
         $this->assertResponseOk();
     }
 
-    public function testDeleteRedirectOk()
+    public function testDeleteRedirectOk(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $this->delete('/surveys/surveys/delete/' . $surveyId);
         $this->assertRedirect(['controller' => 'Surveys', 'action' => 'index']);
     }
 
-    public function testPreviewGet()
+    public function testPreviewGet(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $this->get('/surveys/surveys/preview/' . $surveyId);
@@ -94,7 +113,7 @@ class SurveysControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testAddPostOk()
+    public function testAddPostOk(): void
     {
         $data = [
             'name' => 'Test',
@@ -109,16 +128,22 @@ class SurveysControllerTest extends IntegrationTestCase
 
         $query = $this->Surveys->find()
             ->where(['slug' => 'test_foobar']);
+        /**
+         * @var \Qobo\Survey\Model\Entity\Survey $survey
+         */
         $survey = $query->first();
         $this->assertEquals($survey->slug, $data['slug']);
         $this->assertEquals($survey->name, $data['name']);
     }
 
-    public function testEditPostOk()
+    public function testEditPostOk(): void
     {
         $query = $this->Surveys->find()
             ->limit(1);
 
+        /**
+         * @var \Qobo\Survey\Model\Entity\Survey $survey
+         */
         $survey = $query->first();
         $edit = [
             'name' => 'Modified Name',
@@ -130,14 +155,20 @@ class SurveysControllerTest extends IntegrationTestCase
         $query = $this->Surveys->find()
             ->where(['id' => $survey->id]);
 
+        /**
+         * @var \Qobo\Survey\Model\Entity\Survey $newSurvey
+         */
         $newSurvey = $query->first();
         $this->assertEquals($newSurvey->name, $edit['name']);
     }
 
-    public function testDuplicatePostOk()
+    public function testDuplicatePostOk(): void
     {
         $query = $this->Surveys->find()
             ->limit(1);
+        /**
+         * @var \Qobo\Survey\Model\Entity\Survey $survey
+         */
         $survey = $query->first();
 
         $this->post('/surveys/surveys/duplicate/' . $survey->id);
@@ -145,16 +176,22 @@ class SurveysControllerTest extends IntegrationTestCase
         $query = $this->Surveys->find()
             ->where(['parent_id' => $survey->id]);
 
+        /**
+         * @var \Qobo\Survey\Model\Entity\Survey $duplicated
+         */
         $duplicated = $query->first();
         $this->assertRedirect(['controller' => 'Surveys', 'action' => 'view', $duplicated->id]);
         $this->assertEquals($survey->id, $duplicated->parent_id);
     }
 
-    public function testPublishPostOk()
+    public function testPublishPostOk(): void
     {
         $id = '00000000-0000-0000-0000-000000000002';
         $query = $this->Surveys->find()
             ->where(['id' => $id]);
+        /**
+         * @var \Qobo\Survey\Model\Entity\Survey $survey
+         */
         $survey = $query->first();
 
         $data = [
@@ -170,16 +207,22 @@ class SurveysControllerTest extends IntegrationTestCase
         $query = $this->Surveys->find()
             ->where(['id' => $survey->id]);
 
+        /**
+         * @var \Qobo\Survey\Model\Entity\Survey $published
+         */
         $published = $query->first();
 
         $this->assertNotEmpty($published->publish_date);
         $this->assertEquals($published->publish_date->i18nFormat('yyyy-MM-dd HH:mm:ss'), $data['Surveys']['publish_date']);
     }
 
-    public function testPreviewPost()
+    public function testPreviewPost(): void
     {
         $query = $this->Surveys->find()
             ->limit(1);
+        /**
+         * @var \Qobo\Survey\Model\Entity\Survey $survey
+         */
         $survey = $query->first();
 
         $postData = [];
@@ -209,6 +252,9 @@ class SurveysControllerTest extends IntegrationTestCase
         $query = $this->SurveyResults->find()
             ->where(['result' => 'foobar']);
 
+        /**
+         * @var \Qobo\Survey\Model\Entity\SurveyResult $resultData
+         */
         $resultData = $query->first();
         $this->assertEquals($resultData->survey_id, $survey->id);
         $this->assertEquals($resultData->survey_question_id, $genericId);

--- a/tests/TestCase/Model/Table/SurveyAnswersTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyAnswersTableTest.php
@@ -39,8 +39,12 @@ class SurveyAnswersTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('SurveyAnswers') ? [] : ['className' => SurveyAnswersTable::class];
-        $this->SurveyAnswers = TableRegistry::get('SurveyAnswers', $config);
+        $config = TableRegistry::exists('Survey.SurveyAnswers') ? [] : ['className' => SurveyAnswersTable::class];
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyAnswersTable $table
+         */
+        $table = TableRegistry::get('Survey.SurveyAnswers', $config);
+        $this->SurveyAnswers = $table;
     }
 
     /**
@@ -60,7 +64,7 @@ class SurveyAnswersTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
@@ -70,7 +74,7 @@ class SurveyAnswersTableTest extends TestCase
      *
      * @return void
      */
-    public function testValidationDefault()
+    public function testValidationDefault(): void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
@@ -80,7 +84,7 @@ class SurveyAnswersTableTest extends TestCase
      *
      * @return void
      */
-    public function testBuildRules()
+    public function testBuildRules(): void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }

--- a/tests/TestCase/Model/Table/SurveyQuestionsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyQuestionsTableTest.php
@@ -36,8 +36,12 @@ class SurveyQuestionsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('SurveyQuestions') ? [] : ['className' => SurveyQuestionsTable::class];
-        $this->SurveyQuestions = TableRegistry::get('SurveyQuestions', $config);
+        $config = TableRegistry::exists('Survey.SurveyQuestions') ? [] : ['className' => SurveyQuestionsTable::class];
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $table
+         */
+        $table = TableRegistry::get('Survey.SurveyQuestions', $config);
+        $this->SurveyQuestions = $table;
     }
 
     /**
@@ -52,7 +56,7 @@ class SurveyQuestionsTableTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetQuestionTypes()
+    public function testGetQuestionTypes(): void
     {
         $result = $this->SurveyQuestions->getQuestionTypes();
         $this->assertTrue(is_array($result));

--- a/tests/TestCase/Model/Table/SurveyResultsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyResultsTableTest.php
@@ -61,7 +61,7 @@ class SurveyResultsTableTest extends TestCase
     /**
      * @dataProvider getResultsProvider
      */
-    public function testGetResults($data, $expected)
+    public function testGetResults($data, $expected): void
     {
         $user = ['id' => '123'];
         $survey = (object)[
@@ -104,7 +104,7 @@ class SurveyResultsTableTest extends TestCase
         ];
     }
 
-    public function testSaveData()
+    public function testSaveData(): void
     {
         $survey = $this->Surveys->getSurveyData('survey_-_1', true);
 
@@ -121,7 +121,7 @@ class SurveyResultsTableTest extends TestCase
         $this->assertEquals($result['entity']->result, $data['result']);
     }
 
-    public function testSaveDataErrors()
+    public function testSaveDataErrors(): void
     {
         $survey = $this->Surveys->getSurveyData('survey_-_1', true);
         $data = [

--- a/tests/TestCase/Model/Table/SurveyResultsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyResultsTableTest.php
@@ -20,6 +20,11 @@ class SurveyResultsTableTest extends TestCase
     public $SurveyResults;
 
     /**
+     * @var \Qobo\Survey\Model\Table\SurveysTable
+     */
+    public $Surveys;
+
+    /**
      * Fixtures
      *
      * @var array
@@ -40,10 +45,18 @@ class SurveyResultsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('SurveyResults') ? [] : ['className' => SurveyResultsTable::class];
-        $this->SurveyResults = TableRegistry::get('SurveyResults', $config);
+        $config = TableRegistry::exists('Qobo\Survey.SurveyResults') ? [] : ['className' => SurveyResultsTable::class];
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveyResultsTable $table
+         */
+        $table = TableRegistry::get('SurveyResults', $config);
+        $this->SurveyResults = $table;
 
-        $this->Surveys = TableRegistry::get('Surveys', ['className' => SurveysTable::class]);
+        /**
+         * @var \Qobo\Survey\Model\Table\SurveysTable $table
+         */
+        $table = TableRegistry::get('Surveys', ['className' => SurveysTable::class]);
+        $this->Surveys = $table;
     }
 
     /**
@@ -60,8 +73,10 @@ class SurveyResultsTableTest extends TestCase
 
     /**
      * @dataProvider getResultsProvider
+     * @param mixed[] $data Data
+     * @param int $expected Expected result
      */
-    public function testGetResults($data, $expected): void
+    public function testGetResults(array $data, int $expected): void
     {
         $user = ['id' => '123'];
         $survey = (object)[
@@ -76,7 +91,10 @@ class SurveyResultsTableTest extends TestCase
         $this->assertEquals(count($result), $expected);
     }
 
-    public function getResultsProvider()
+    /**
+     * @return mixed[]
+     */
+    public function getResultsProvider(): array
     {
         return [
             [

--- a/tests/TestCase/Model/Table/SurveyResultsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyResultsTableTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Qobo\Survey\Test\TestCase\Model\Table;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Qobo\Survey\Model\Table\SurveyResultsTable;
@@ -124,13 +125,18 @@ class SurveyResultsTableTest extends TestCase
 
     public function testSaveData(): void
     {
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $survey = $this->Surveys->getSurveyData('survey_-_1', true);
+
+        $this->assertInstanceOf(EntityInterface::class, $survey);
 
         $data = [
             'user_id' => '00000000-0000-0000-0000-000000000001',
-            'survey_id' => $survey->id,
-            'survey_question_id' => $survey->survey_questions[0]->id,
-            'survey_answer_id' => $survey->survey_questions[0]->survey_answers[0]->id,
+            'survey_id' => $survey->get('id'),
+            'survey_question_id' => $survey->get('survey_questions')[0]->get('id'),
+            'survey_answer_id' => $survey->get('survey_questions')[0]->get('survey_answers')[0]->get('id'),
             'result' => 'w00t',
         ];
 
@@ -141,12 +147,15 @@ class SurveyResultsTableTest extends TestCase
 
     public function testSaveDataErrors(): void
     {
+        /**
+         * @var \Cake\Datasource\EntityInterface
+         */
         $survey = $this->Surveys->getSurveyData('survey_-_1', true);
         $data = [
             'user_id' => '00000000-0000-0000-0000-000000000001',
             'survey_id' => $survey->id,
             'survey_answer_id' => null,
-            'survey_question_id' => $survey->survey_questions[0]->id,
+            'survey_question_id' => $survey->get('survey_questions')[0]->get('id'),
             'result' => 'w00t',
         ];
 

--- a/tests/TestCase/Model/Table/SurveysTableTest.php
+++ b/tests/TestCase/Model/Table/SurveysTableTest.php
@@ -59,7 +59,7 @@ class SurveysTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
@@ -69,19 +69,19 @@ class SurveysTableTest extends TestCase
      *
      * @return void
      */
-    public function testValidationDefault()
+    public function testValidationDefault(): void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
 
-    public function testGetSurveyCategories()
+    public function testGetSurveyCategories(): void
     {
         $result = $this->Surveys->getSurveyCategories();
         $this->assertTrue(is_array($result));
         $this->assertEquals($result['test_default'], 'Test Default');
     }
 
-    public function testGetSurveyData()
+    public function testGetSurveyData(): void
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $result = $this->Surveys->getSurveyData(null);
@@ -100,7 +100,7 @@ class SurveysTableTest extends TestCase
         $this->assertEquals($result->id, $surveyId);
     }
 
-    public function testSetSequentialOrder()
+    public function testSetSequentialOrder(): void
     {
         $id = '00000000-0000-0000-0000-000000000002';
         $survey = $this->Surveys->getSurveyData($id, true);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,7 +46,7 @@ require ROOT . '/vendor/autoload.php';
 require CORE_PATH . 'config/bootstrap.php';
 
 Configure::write('App', [
-    'namespace' => $pluginName . '\Test\App',
+    'namespace' => 'Qobo\\' . $pluginName . '\Test\App',
     'paths' => [
         'templates' => [
             APP . 'Template' . DS

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,37 +1,34 @@
 <?php
-// @codingStandardsIgnoreFile
-
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 
 $pluginName = 'Survey';
 if (empty($pluginName)) {
-    throw new \Exception("Plugin name is not configured");
+    throw new \RuntimeException("Plugin name is not configured");
 }
 
-$findRoot = function () {
-    $root = dirname(__DIR__);
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(__DIR__));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(dirname(__DIR__)));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    throw new \Exception("Failed to find CakePHP");
+/*
+ * Test suite bootstrap
+ *
+ * This function is used to find the location of CakePHP whether CakePHP
+ * has been installed as a dependency of the plugin, or the plugin is itself
+ * installed as a dependency of an application.
+ */
+$findRoot = function ($root) {
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
+    throw new \RuntimeException("Failed to find CakePHP");
 };
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
 }
-define('ROOT', $findRoot());
+define('ROOT', $findRoot(__FILE__));
 define('APP_DIR', 'App');
 define('WEBROOT_DIR', 'webroot');
 define('APP', ROOT . '/tests/App/');
@@ -89,7 +86,7 @@ $cache = [
     ]
 ];
 
-Cake\Cache\Cache::config($cache);
+Cake\Cache\Cache::setConfig($cache);
 Cake\Core\Configure::write('Session', [
     'defaults' => 'php'
 ]);
@@ -99,13 +96,13 @@ if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
 
-Cake\Datasource\ConnectionManager::config('default', [
+Cake\Datasource\ConnectionManager::setConfig('default', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
 ]);
 
-Cake\Datasource\ConnectionManager::config('test', [
+Cake\Datasource\ConnectionManager::setConfig('test', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
@@ -114,9 +111,6 @@ Cake\Datasource\ConnectionManager::config('test', [
 // Alias AppController to the test App
 class_alias('Qobo\\' . $pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
 // If plugin has routes.php/bootstrap.php then load them, otherwise don't.
-$loadPluginRoutes = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'routes.php');
-$loadPluginBootstrap = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'bootstrap.php');
+$loadPluginRoutes = file_exists(ROOT . DS . 'config' . DS . 'routes.php');
+$loadPluginBootstrap = file_exists(ROOT . DS . 'config' . DS . 'bootstrap.php');
 Cake\Core\Plugin::load('Qobo/' . $pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
-
-Cake\Routing\DispatcherFactory::add('Routing');
-Cake\Routing\DispatcherFactory::add('ControllerFactory');

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -5,10 +5,4 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Routing\Router;
 
-/**
- * Load all plugin routes.  See the Plugin documentation on
- * how to customize the loading of plugin routes.
- */
-Plugin::routes();
-
 Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -1,8 +1,37 @@
 <?php
 namespace Qobo\Survey\Test\App\Config;
 
-use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\Routing\Router;
+use Cake\Routing\Route\DashedRoute;
 
-Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);
+Router::defaultRouteClass(DashedRoute::class);
+
+Router::connect('/:controller/:action/*');
+Router::plugin(
+    'Qobo/Survey',
+    ['path' => '/surveys'],
+    function ($routes) {
+        $routes->setExtensions(['json']);
+
+        $routes->scope('/survey', function ($routes) {
+            $routes->connect(
+                '/:slug/questions/:action/*',
+                ['controller' => 'SurveyQuestions'],
+                ['pass' => ['slug']]
+            );
+
+            $routes->connect(
+                '/:slug/answers/:action/*',
+                ['controller' => 'SurveyAnswers'],
+                ['pass' => ['slug']]
+            );
+
+            $routes->connect(
+                '/:slug/results/:action/*',
+                ['controller' => 'SurveyResults'],
+                ['pass' => ['slug']]
+            );
+        });
+        $routes->fallbacks('DashedRoute');
+    }
+);


### PR DESCRIPTION
* Updated to [cakephp-plugin-template v5.2.1](https://github.com/QoboLtd/cakephp-plugin-template/releases/tag/v5.2.1).
* Updated `composer.json`.
* Fixed all of deprecated errors for CakePHP 3.6.
* Fixed all of PHPStan issues.
* Enabled PHPStan on TravisCI.