### PR TITLE
Move questions under corresponding sections

### DIFF
--- a/src/Controller/SurveySectionsController.php
+++ b/src/Controller/SurveySectionsController.php
@@ -156,13 +156,17 @@ class SurveySectionsController extends AppController
 
         $survey = $this->Surveys->getSurveyData($surveyId);
         $questionTypes = $this->SurveyQuestions->getQuestionTypes();
-        $section = $this->SurveySections->find()
+
+        /** @var \Cake\ORM\Query $query */
+        $query = $this->SurveySections->find()
             ->enableHydration(true)
             ->where([
                 'id' => $id,
             ])
-            ->contain(['SurveyQuestions'])
-            ->first();
+            ->contain(['SurveyQuestions']);
+
+        $section = $query->first();
+        Assert::isInstanceOf($section, EntityInterface::class);
 
         $this->set(compact('section', 'survey', 'questionTypes'));
     }

--- a/src/Controller/SurveySectionsController.php
+++ b/src/Controller/SurveySectionsController.php
@@ -148,6 +148,26 @@ class SurveySectionsController extends AppController
     }
 
     /**
+     * @return \Cake\Http\Response|void|null Redirects to index.
+     */
+    public function view(string $surveyId, string $id)
+    {
+        $this->request->allowMethod(['get']);
+
+        $survey = $this->Surveys->getSurveyData($surveyId);
+        $questionTypes = $this->SurveyQuestions->getQuestionTypes();
+        $section = $this->SurveySections->find()
+            ->enableHydration(true)
+            ->where([
+                'id' => $id,
+            ])
+            ->contain(['SurveyQuestions'])
+            ->first();
+
+        $this->set(compact('section', 'survey', 'questionTypes'));
+    }
+
+    /**
      * Delete method
      *
      * @param string $surveyId of the survey
@@ -158,7 +178,9 @@ class SurveySectionsController extends AppController
     public function delete(string $surveyId, ?string $id)
     {
         $this->request->allowMethod(['post', 'delete']);
+
         $surveySection = $this->SurveySections->get($id);
+
         if ($this->SurveySections->delete($surveySection)) {
             $this->Flash->success((string)__('The survey section has been deleted.'));
         } else {

--- a/src/Template/Element/SurveyQuestions/view.ctp
+++ b/src/Template/Element/SurveyQuestions/view.ctp
@@ -54,7 +54,6 @@ $surveyId = !empty($survey->slug) ? $survey->slug : $survey->id;
                     <?= $this->Form->postLink('<i class="fa fa-arrow-up"></i>', ['controller' => 'SurveyQuestions', 'action' => 'move', $surveyQuestion->id, 'up'], ['escape' => false, 'class' => 'btn btn-default']);?>
                     <?= $this->Form->postLink('<i class="fa fa-arrow-down"></i>', ['controller' => 'SurveyQuestions', 'action' => 'move', $surveyQuestion->id, 'down'], ['escape' => false, 'class' => 'btn btn-default']);?>
                 <?php endif; ?>
-                <?= $this->Html->link('<i class="fa fa-file"></i>', ['controller' => 'SurveyQuestions', 'action' => 'preview', $surveyId, $surveyQuestion->id], ['escape' => false, 'class' => 'btn btn-default', 'title' => __('Preview')]) ?>
                 <?= $this->Html->link('<i class="fa fa-eye"></i>', ['controller' => 'SurveyQuestions', 'action' => 'view', $surveyId, $surveyQuestion->id], ['escape' => false, 'class' => 'btn btn-default', 'title' => __('View')]) ?>
                 <?php if (empty($survey->publish_date)) : ?>
                     <?= $this->Html->link('<i class="fa fa-pencil"></i>', ['controller' => 'SurveyQuestions', 'action' => 'edit', $surveyId, $surveyQuestion->id], ['escape' => false, 'class' => 'btn btn-default']) ?>

--- a/src/Template/Element/SurveySections/view.ctp
+++ b/src/Template/Element/SurveySections/view.ctp
@@ -51,8 +51,9 @@ $surveyId = !empty($survey->slug) ? $survey->slug : $survey->id;
                     <?php if (empty($survey->get('pubish_date'))) : ?>
                         <?= $this->Form->postLink('<i class="fa fa-arrow-up"></i>', ['controller' => 'SurveySections', 'action' => 'move', $item->get('id'), 'up'], ['escape' => false, 'class' => 'btn btn-default']) ?>
                         <?= $this->Form->postLink('<i class="fa fa-arrow-down"></i>', ['controller' => 'SurveySections', 'action' => 'move', $item->get('id'), 'down'], ['escape' => false, 'class' => 'btn btn-default']) ?>
-
+                        <?= $this->Html->link('<i class="fa fa-eye"></i>', ['controller' => 'SurveySections', 'action' => 'view', $surveyId, $item->get('id')], ['escape' => false, 'class' => 'btn btn-default']) ?>
                         <?= $this->Html->link('<i class="fa fa-pencil"></i>', ['controller' => 'SurveySections', 'action' => 'edit', $surveyId, $item->get('id')], ['escape' => false, 'class' => 'btn btn-default']) ?>
+
                         <?php if (! $hasQuestions) : ?>
                             <?= $this->Form->postLink('<i class="fa fa-trash"></i>', ['controller' => 'SurveySections', 'action' => 'delete', $surveyId, $item->get('id')], ['escape' => false, 'class' => 'btn btn-default', 'confirm' => __('Are you sure you want to delete {0}?', $item->get('name'))]) ?>
                         <?php endif; ?>

--- a/src/Template/Element/SurveySections/view_questions.ctp
+++ b/src/Template/Element/SurveySections/view_questions.ctp
@@ -1,0 +1,56 @@
+<?php
+$surveyId = !empty($survey->get('slug')) ? $survey->get('slug') : $survey->get('id');
+
+?>
+<div class="row">
+    <div class="col-xs-12 col-md-12">
+        <div class="pull-right">
+            <div class="btn-group btn-group-sm" role="group">
+                <?php if (empty($survey->publish_date)) : ?>
+                    <?= $this->Html->link(
+                        '<i class="fa fa-plus"></i> ' . __('Add Question'),
+                        ['controller' => 'SurveyQuestions', 'action' => 'add', $surveyId],
+                        ['class' => 'btn btn-default', 'escape' => false]
+                    )?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>
+
+<table class="table table-hover table-condensed table-vertical-align table-datatable" width="100%">
+    <thead>
+        <tr>
+            <th scope="col"><?= __('Order') ?></th>
+            <th scope="col"><?= __('Question') ?></th>
+            <th scope="col"><?= __('Type') ?> </th>
+            <th scope="col"><?= __('Active') ?></th>
+            <th scope="col"><?= __('Required') ?></th>
+            <th scope="col" class="actions"><?= __('Actions') ?></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($section->get('survey_questions') as $surveyQuestion) : ?>
+        <tr>
+            <td><?= h($surveyQuestion->order) ?></td>
+            <td><?= h($surveyQuestion->question) ?></td>
+            <td><?= h($questionTypes[$surveyQuestion->get('type')]) ?> </td>
+            <td><?= h($surveyQuestion->active ? __('Yes') : __('No')) ?></td>
+            <td><?= h($surveyQuestion->is_required ? __('Yes') : __('No')) ?></td>
+            <td class="actions">
+                <div class="btn-group btn-group-xs">
+                <?php if (empty($survey->publish_date)) : ?>
+                    <?= $this->Form->postLink('<i class="fa fa-arrow-up"></i>', ['controller' => 'SurveyQuestions', 'action' => 'move', $surveyQuestion->id, 'up'], ['escape' => false, 'class' => 'btn btn-default']);?>
+                    <?= $this->Form->postLink('<i class="fa fa-arrow-down"></i>', ['controller' => 'SurveyQuestions', 'action' => 'move', $surveyQuestion->id, 'down'], ['escape' => false, 'class' => 'btn btn-default']);?>
+                <?php endif; ?>
+                <?= $this->Html->link('<i class="fa fa-eye"></i>', ['controller' => 'SurveyQuestions', 'action' => 'view', $surveyId, $surveyQuestion->id], ['escape' => false, 'class' => 'btn btn-default', 'title' => __('View')]) ?>
+                <?php if (empty($survey->publish_date)) : ?>
+                    <?= $this->Html->link('<i class="fa fa-pencil"></i>', ['controller' => 'SurveyQuestions', 'action' => 'edit', $surveyId, $surveyQuestion->id], ['escape' => false, 'class' => 'btn btn-default']) ?>
+                    <?= $this->Form->postLink('<i class="fa fa-trash"></i>', ['controller' => 'SurveyQuestions', 'action' => 'delete', $surveyId, $surveyQuestion->id], ['escape' => false, 'class' => 'btn btn-default', 'confirm' => __('Are you sure you want to delete # {0}?', $surveyQuestion->id)]) ?>
+                <?php endif;?>
+                </div>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>

--- a/src/Template/SurveyQuestions/add.ctp
+++ b/src/Template/SurveyQuestions/add.ctp
@@ -12,17 +12,11 @@
 
 $surveyId = empty($survey->slug) ? $survey->id : $survey->slug;
 
-$options['title'] = $this->Html->link(__('Surveys'), [
-    'controller' => 'Surveys',
-    'action' => 'index'
-]);
-$options['title'] .= " &raquo; ";
-$options['title'] .= $this->Html->link(
-    $survey->name,
-    ['controller' => 'Surveys', 'action' => 'view', $surveyId]
+$options['title'] = __(
+    '{0} &raquo; {1} &raquo; Add Question',
+    $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]),
 );
-$options['title'] .= " &raquo; ";
-$options['title'] .= __('Add {0}', ['Survey Question']);
 ?>
 <section class="content-header">
     <div class="row">

--- a/src/Template/SurveyQuestions/add.ctp
+++ b/src/Template/SurveyQuestions/add.ctp
@@ -15,7 +15,7 @@ $surveyId = empty($survey->slug) ? $survey->id : $survey->slug;
 $options['title'] = __(
     '{0} &raquo; {1} &raquo; Add Question',
     $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
-    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]),
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId])
 );
 ?>
 <section class="content-header">

--- a/src/Template/SurveyQuestions/edit.ctp
+++ b/src/Template/SurveyQuestions/edit.ctp
@@ -15,7 +15,7 @@ $surveyId = empty($survey->slug) ? $survey->id : $survey->slug;
 $options['title'] = __(
     '{0} &raquo; {1} &raquo; Edit Question',
     $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
-    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]),
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId])
 );
 ?>
 <section class="content-header">

--- a/src/Template/SurveyQuestions/edit.ctp
+++ b/src/Template/SurveyQuestions/edit.ctp
@@ -11,12 +11,12 @@
  */
 
 $surveyId = empty($survey->slug) ? $survey->id : $survey->slug;
-$options['title'] = $this->Html->link(
-    $survey->name,
-    ['controller' => 'Surveys', 'action' => 'view', $surveyId]
+
+$options['title'] = __(
+    '{0} &raquo; {1} &raquo; Edit Question',
+    $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]),
 );
-$options['title'] .= " &raquo; ";
-$options['title'] .= __('Add {0}', ['Survey Question']);
 ?>
 <section class="content-header">
     <div class="row">

--- a/src/Template/SurveyQuestions/preview.ctp
+++ b/src/Template/SurveyQuestions/preview.ctp
@@ -10,8 +10,9 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 $options['title'] = __(
-    '{0} &raquo; Preview Question',
-    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $survey->get('slug')])
+    '{0} &raquo; {1} &raquo; Preview Question',
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $survey->get('slug')]),
+    $this->Html->link($surveyQuestion->get('question'), ['controller' => 'SurveyQuestions', 'action' => 'view', $survey->get('id'), $surveyQuestion->get('id')])
 );
 ?>
 <section class="content-header">
@@ -72,4 +73,9 @@ $options['title'] = __(
         </div>
     </div>
     <?php endif; ?>
+<?= $this->Html->link(
+    __('Back'),
+    ['controller' => 'SurveyQuestions', 'action' => 'view', $survey->get('id'), $surveyQuestion->get('id')],
+    ['class' => 'btn btn-success']
+)?>
 </section>

--- a/src/Template/SurveyQuestions/preview.ctp
+++ b/src/Template/SurveyQuestions/preview.ctp
@@ -9,7 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-$option['title'] = __(
+$options['title'] = __(
     '{0} &raquo; Preview Question',
     $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $survey->get('slug')])
 );

--- a/src/Template/SurveyQuestions/preview.ctp
+++ b/src/Template/SurveyQuestions/preview.ctp
@@ -9,9 +9,10 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-$options['title'] = $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $survey->get('slug')]);
-$options['title'] .= ' &raquo; ';
-$options['title'] .= 'Preview Question';
+$option['title'] = __(
+    '{0} &raquo; Preview Question',
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $survey->get('slug')])
+);
 ?>
 <section class="content-header">
     <div class="row">

--- a/src/Template/SurveyQuestions/view.ctp
+++ b/src/Template/SurveyQuestions/view.ctp
@@ -10,13 +10,11 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 $surveyId = empty($survey->slug) ? $survey->id : $survey->slug;
-$options['title'] = $this->Html->link(
-    $survey->name,
-    ['controller' => 'Surveys', 'action' => 'view', $surveyId]
+$options['title'] = __(
+    '{0} &raquo; "{1}" question',
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]),
+    $surveyQuestion->get('question')
 );
-$options['title'] .= " &raquo; ";
-$options['title'] .= '"' . $surveyQuestion->get('question') . '" question';
-
 ?>
 <section class="content-header">
     <div class="row">

--- a/src/Template/SurveyQuestions/view.ctp
+++ b/src/Template/SurveyQuestions/view.ctp
@@ -9,10 +9,12 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-$surveyId = empty($survey->slug) ? $survey->id : $survey->slug;
+$surveyId = empty($survey->get('slug')) ? $survey->get('id') : $survey->get('slug');
+
 $options['title'] = __(
-    '{0} &raquo; "{1}" question',
+    '{0} &raquo; {1} &raquo; "{2}" question',
     $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]),
+    $this->Html->link(__('Current Section'), ['controller' => 'SurveySections', 'action' => 'view', $survey->get('id'), $surveyQuestion->get('survey_section_id')]),
     $surveyQuestion->get('question')
 );
 ?>
@@ -26,19 +28,19 @@ $options['title'] = __(
             <div class="btn-group btn-group-sm" role="group">
             <?= $this->Html->link(
                 '<i class="fa fa-file"></i> ' . __('Preview'),
-                ['controller' => 'SurveyQuestions', 'action' => 'preview', $surveyId, $surveyQuestion->id],
+                ['controller' => 'SurveyQuestions', 'action' => 'preview', $surveyId, $surveyQuestion->get('id')],
                 ['class' => 'btn btn-default', 'title' => __('Preview'), 'escape' => false]
             )?>
-            <?php if (empty($survey->publish_date)) : ?>
+            <?php if (empty($survey->get('publish_date'))) : ?>
                 <?= $this->Html->link(
                     '<i class="fa fa-pencil"></i> ' . __('Edit'),
-                    ['controller' => 'SurveyQuestions', 'action' => 'edit', $surveyId, $surveyQuestion->id],
+                    ['controller' => 'SurveyQuestions', 'action' => 'edit', $surveyId, $surveyQuestion->get('id')],
                     ['class' => 'btn btn-default', 'title' => __('Edit'), 'escape' => false]
                 )?>
                 <?= $this->Form->postLink(
                     '<i class="fa fa-trash"></i> ' . __('Delete'),
-                    ['controller' => 'SurveyQuestions', 'action' => 'delete', $surveyId, $surveyQuestion->id],
-                    ['class' => 'btn btn-default', 'title' => __('Delete'), 'escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $surveyQuestion->id)]
+                    ['controller' => 'SurveyQuestions', 'action' => 'delete', $surveyId, $surveyQuestion->get('id')],
+                    ['class' => 'btn btn-default', 'title' => __('Delete'), 'escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $surveyQuestion->get('id'))]
                 )?>
             <?php endif; ?>
             </div>
@@ -63,62 +65,62 @@ $options['title'] = __(
                     <strong><?= __('ID') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= h($surveyQuestion->id) ?>
+                    <?= h($surveyQuestion->get('id')) ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Survey') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= $this->Html->link($survey->name, ['controller' => 'Surveys', 'action' => 'view', $surveyId]) ?>
+                    <?= $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]) ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Type') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= $questionTypes[$surveyQuestion->type] ?>
+                    <?= $questionTypes[$surveyQuestion->get('type')] ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Active') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= $surveyQuestion->active ? __('Yes') : __('No'); ?>
+                    <?= $surveyQuestion->get('active') ? __('Yes') : __('No'); ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Required') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= $surveyQuestion->is_required ? __('Yes') : __('No'); ?>
+                    <?= $surveyQuestion->get('is_required') ? __('Yes') : __('No'); ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Question') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= $this->Text->autoParagraph(h($surveyQuestion->question)); ?>
+                    <?= $this->Text->autoParagraph(h($surveyQuestion->get('question'))); ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Created') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= h($surveyQuestion->created->i18nFormat('yyyy-MM-dd HH:mm')) ?>
+                    <?= h($surveyQuestion->get('created')->i18nFormat('yyyy-MM-dd HH:mm')) ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Modified') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
-                    <?= h($surveyQuestion->modified->i18nFormat('yyyy-MM-dd HH:mm')) ?>
+                    <?= h($surveyQuestion->get('modified')->i18nFormat('yyyy-MM-dd HH:mm')) ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
             </div>
         </div>
     </div>
-    <?php if (!empty($surveyQuestion->extras)) : ?>
+    <?php if (!empty($surveyQuestion->get('extras'))) : ?>
     <div class="box box-primary">
         <div class="box-header with-border">
             <h3 class="box-title"><?= __('Details'); ?></h3>
@@ -129,7 +131,7 @@ $options['title'] = __(
             </div>
         </div>
         <div class="box-body">
-            <?= $surveyQuestion->extras ?>
+            <?= $surveyQuestion->get('extras') ?>
         </div>
     </div>
     <?php endif; ?>

--- a/src/Template/SurveySections/add.ctp
+++ b/src/Template/SurveySections/add.ctp
@@ -21,17 +21,11 @@ echo $this->Html->script([
     'Cms.icheck.init',
     ], ['block' => 'scriptBottom']);
 
-$options['title'] = $this->Html->link(
-    $survey->get('name'),
-    [
-        'controller' => 'Surveys',
-        'action' => 'view',
-        $survey->get('slug')
-    ]);
-$options['title'] .= ' &raquo; ';
-$options['title'] .= __('Create {0}', ['Survey Section']);
+$options['title'] = __(
+    '{0} &raquo; Create Survey Section',
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $survey->get('slug')])
+);
 ?>
-
 <section class="content-header">
     <div class="row">
         <div class="col-xs-12 col-md-6">

--- a/src/Template/SurveySections/edit.ctp
+++ b/src/Template/SurveySections/edit.ctp
@@ -28,15 +28,11 @@ if (!empty($surveySection->get('survey_questions'))) {
     }
 }
 
-$options['title'] = $this->Html->link(
-    $survey->get('name'),
-    [
-        'controller' => 'Surveys',
-        'action' => 'view',
-        $survey->get('slug')
-    ]);
-$options['title'] .= ' &raquo; ';
-$options['title'] .= __('Edit "{0}"', [$surveySection->get('name')]);
+$options['title'] = __(
+    '{0} &raquo; Edit {1}',
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $survey->get('slug')]),
+    $surveySection->get('name')
+);
 ?>
 <section class="content-header">
     <div class="row">

--- a/src/Template/SurveySections/view.ctp
+++ b/src/Template/SurveySections/view.ctp
@@ -1,0 +1,91 @@
+<?php
+
+$surveyId = !empty($survey->slug) ? $survey->slug : $survey->id;
+
+$options['title'] = __(
+    '{0} &raquo; {1} &raquo; {2}',
+    $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]),
+    $section->get('name')
+);
+?>
+<section class="content-header">
+    <div class="row">
+        <div class="col-xs-12 col-md-6">
+            <h4><?= $options['title'] ?></h4>
+        </div>
+    </div>
+</section>
+
+<section class="content">
+    <div class="box box-primary">
+        <div class="box-header with-border">
+            <h3 class="box-title"><?= __('Details'); ?></h3>
+            <div class="box-tools pull-right">
+                <button type="button" class="btn btn-box-tool" data-widget="collapse">
+                    <i class="fa fa-minus"></i>
+                </button>
+            </div>
+        </div>
+        <div class="box-body">
+            <div class="row">
+                <div class="col-xs-4 col-md-2 text-right">
+                    <strong><?= __('Name') ?>:</strong>
+                </div>
+                <div class="col-xs-8 col-md-4">
+                    <?= h($section->get('name')) ?>
+                </div>
+                <div class="clearfix visible-xs visible-sm"></div>
+                <div class="col-xs-4 col-md-2 text-right">
+                    <strong><?= __('ID') ?>:</strong>
+                </div>
+                <div class="col-xs-8 col-md-4">
+                    <?= h($section->get('id')) ?>
+                </div>
+                <div class="clearfix visible-xs visible-sm"></div>
+            </div>
+            <div class="row">
+                <div class="col-xs-4 col-md-2 text-right">
+                    <strong><?= __('Active') ?>:</strong>
+                </div>
+                <div class="col-xs-8 col-md-4">
+                    <?= $section->get('active') ? __('Yes') : __('No'); ?>
+                </div>
+                <div class="clearfix visible-xs visible-sm"></div>
+                <div class="col-xs-4 col-md-2 text-right">
+                    <strong><?= __('Order') ?>:</strong>
+                </div>
+                <div class="col-xs-8 col-md-4">
+                    <?= h($section->get('order')) ?>
+                </div>
+                <div class="clearfix visible-xs visible-sm"></div>
+            </div>
+            <div class="row">
+                <div class="col-xs-4 col-md-2 text-right">
+                    <strong><?= __('Default Section') ?>:</strong>
+                </div>
+                <div class="col-xs-8 col-md-4">
+                    <?= $section->get('is_default') ? __('Yes') : __('No'); ?>
+                </div>
+                <div class="clearfix visible-xs visible-sm"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="nav-tabs-custom">
+        <ul id="relatedTabs" class="nav nav-tabs" role="tablist">
+            <li role="presentation">
+                <a href="#manage-survey-questions" aria-controls="manage-content" role="tab" data-toggle="tab">
+                    <i class="fa fa-list-ul"></i> <i class="fa question-circle"></i> <?= __('Questions'); ?>
+                </a>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane" id="manage-survey-questions">
+                <?= $this->element('Qobo/Survey.SurveySections/view_questions', ['survey' => $survey, 'section' => $section]); ?>
+            </div>
+        </div>
+    </div>
+
+
+</section>

--- a/src/Template/Surveys/index.ctp
+++ b/src/Template/Surveys/index.ctp
@@ -9,7 +9,7 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-$options['title'] = 'Surveys';
+$options['title'] = __('Surveys');
 ?>
 <section class="content-header">
     <div class="row">

--- a/src/Template/Surveys/preview.ctp
+++ b/src/Template/Surveys/preview.ctp
@@ -14,18 +14,12 @@ use Cake\Utility\Text;
 
 $surveyId = empty($survey->get('slug')) ? $survey->get('id') : $survey->get('slug');
 
-$options['title'] = $this->Html->link(__('Surveys'), [
-    'controller' => 'Surveys',
-    'action' => 'index'
-]);
-$options['title'] .= " &raquo; ";
-$options['title'] .= $this->Html->link($survey->name, [
-    'controller' => 'Surveys',
-    'action' => 'view',
-    $surveyId
-]);
-$options['title'] .= " &raquo; ";
-$options['title'] .= __('Preview');
+$options['title'] = __(
+    '{0} &raquo; {1} &raquo; Preview',
+     $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
+     $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId])
+);
+
 $count = 1;
 ?>
 <section class="content-header">

--- a/src/Template/Surveys/publish.ctp
+++ b/src/Template/Surveys/publish.ctp
@@ -17,11 +17,18 @@ echo $this->Html->script([
     ], [
         'block' => 'scriptBottom'
     ]);
+
+$options['title'] = __(
+    '{0} &raquo; {1} &raquo; Publishing survey',
+    $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
+    $this->Html->link( $survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $survey->get('id')])
+);
+
 ?>
 <section class="content-header">
     <div class="row">
         <div class="col-xs-12 col-md-6">
-            <h4><?= __('Survey Publish date setting');?></h4>
+            <h4><?= $options['title'] ?></h4>
         </div>
     </div>
 </section>
@@ -70,9 +77,20 @@ echo $this->Html->script([
                     ]) ?>
                 </div>
             </div>
-            <?= $this->Form->button(__('Submit')) ?>
-            <?= $this->Html->link(__('Cancel'), ['plugin' => 'Qobo/Survey', 'controller' => 'Surveys', 'action' => 'view', $survey->get('id')]) ?>
-            <?= $this->Form->end() ?>
-        </div>
-    </div>
+                </div>
+
+            </div>
+        <?= $this->Form->button(__('Submit')) ?>
+        <?= $this->Html->link(
+            __('Cancel'),
+            [
+                'plugin' => 'Qobo/Survey',
+                'controller' => 'Surveys',
+                'action' => 'view',
+                $survey->get('id')
+            ],
+            [
+                'class' => 'btn btn-link    '
+            ]) ?>
+        <?= $this->Form->end() ?>
 </section>

--- a/src/Template/Surveys/view.ctp
+++ b/src/Template/Surveys/view.ctp
@@ -165,11 +165,6 @@ $options['title'] = __(
                 </a>
             </li>
             <li role="presentation">
-                <a href="#manage-survey-questions" aria-controls="manage-content" role="tab" data-toggle="tab">
-                    <i class="fa fa-question-circle"></i> <i class="fa question-circle"></i> <?= __('All Questions'); ?>
-                </a>
-            </li>
-            <li role="presentation">
                 <a href="#manage-survey-results" aria-controls="manage-survey-results" role="tab" data-toggle="tab">
                     <i class="fa fa-check-circle"></i> <?= __('Overview'); ?>
                 </a>
@@ -181,9 +176,6 @@ $options['title'] = __(
             </li>
         </ul>
         <div class="tab-content">
-            <div role="tabpanel" class="tab-pane" id="manage-survey-questions">
-                <?= $this->element('Qobo/Survey.SurveyQuestions/view', ['survey' => $survey]); ?>
-            </div>
             <div role="tabpanel" class="tab-pane" id="manage-survey-sections">
                 <?= $this->element('Qobo/Survey.SurveySections/view', ['survey' => $survey]); ?>
             </div>

--- a/src/Template/Surveys/view.ctp
+++ b/src/Template/Surveys/view.ctp
@@ -34,8 +34,11 @@ echo $this->Html->script(
 
 $surveyId = !empty($survey->slug) ? $survey->slug : $survey->id;
 
-$options['title'] = $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']);
-$options['title'] .= ' &raquo; ' . $survey->name;
+$options['title'] = __(
+    '{0} &raquo; {1}',
+    $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
+    $survey->get('name')
+);
 ?>
 <section class="content-header">
     <div class="row">

--- a/src/Template/Surveys/view.ctp
+++ b/src/Template/Surveys/view.ctp
@@ -107,27 +107,35 @@ $options['title'] .= ' &raquo; ' . $survey->name;
             </div>
             <div class="row">
                 <div class="col-xs-4 col-md-2 text-right">
-                    <strong><?= __('Publish Date') ?>:</strong>
-                </div>
-                <div class="col-xs-8 col-md-4">
-                    <?= empty($survey->publish_date) ? 'N/A' : $survey->publish_date->i18nFormat('yyyy-MM-dd HH:mm') ?>
-                </div>
-                <div class="clearfix visible-xs visible-sm"></div>
-                <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Slug') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
                     <?= h($survey->slug) ?>
                 </div>
                 <div class="clearfix visible-xs visible-sm"></div>
+                <div class="col-xs-4 col-md-2 text-right">
+                    <strong><?= __('Publish Date') ?>:</strong>
+                </div>
+                <div class="col-xs-8 col-md-4">
+                    <?= empty($survey->publish_date) ? 'N/A' : $survey->publish_date->i18nFormat('yyyy-MM-dd HH:mm') ?>
+                </div>
+                <div class="clearfix visible-xs visible-sm"></div>
             </div>
             <div class="row">
+                <div class="col-xs-4 col-md-2 text-right">
+                    <strong><?= __('Description') ?>:</strong>
+                </div>
+                <div class="col-xs-8 col-md-4">
+                    <?= $this->Text->autoParagraph(h($survey->description)); ?>
+                </div>
+                <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Active') ?>:</strong>
                 </div>
                 <div class="col-xs-8 col-md-4">
                     <?= $survey->active ? __('Yes') : __('No'); ?>
                 </div>
+                <div class="clearfix visible-xs visible-sm"></div>
                 <div class="col-xs-4 col-md-2 text-right">
                     <strong><?= __('Expiry Date') ?>:</strong>
                 </div>
@@ -155,7 +163,7 @@ $options['title'] .= ' &raquo; ' . $survey->name;
             </li>
             <li role="presentation">
                 <a href="#manage-survey-questions" aria-controls="manage-content" role="tab" data-toggle="tab">
-                    <i class="fa fa-question-circle"></i> <i class="fa question-circle"></i> <?= __('Questions'); ?>
+                    <i class="fa fa-question-circle"></i> <i class="fa question-circle"></i> <?= __('All Questions'); ?>
                 </a>
             </li>
             <li role="presentation">
@@ -165,7 +173,7 @@ $options['title'] .= ' &raquo; ' . $survey->name;
             </li>
             <li role="presentation">
                 <a href="#manage-survey-submits" aria-controls="manage-survey-submits" role="tab" data-toggle="tab">
-                    <i class="fa fa-chart-line"></i> <?= __('Results'); ?>
+                    <i class="fa fa-signal"></i> <?= __('Results'); ?>
                 </a>
             </li>
         </ul>

--- a/src/Template/Surveys/view_submit.ctp
+++ b/src/Template/Surveys/view_submit.ctp
@@ -9,16 +9,14 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-$order = 1;
-
 $surveyId = empty($survey->slug) ? $survey->id : $survey->slug;
-$options['title'] = $this->Html->link(
-    $survey->name,
-    ['controller' => 'Surveys', 'action' => 'view', $surveyId]
+
+$options['title'] = __(
+    '{0} &raquo; Submission Details',
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId])
 );
 
-$options['title'] .= ' &raquo; ';
-$options['title'] .= __('Submission Details');
+$order = 1;
 ?>
 <section class="content-header">
     <div class="row">


### PR DESCRIPTION
* To ensure usability, questions are now moved under corresponding sections
* Improved navigation breadcrumbs
* Placed 'preview' functionality under corresponding entities of Survey sections.