### PR TITLE
Adding scores to actual submits

### DIFF
--- a/config/Migrations/20190823100202_AddScoreToSurveyResults.php
+++ b/config/Migrations/20190823100202_AddScoreToSurveyResults.php
@@ -1,0 +1,29 @@
+<?php
+use Migrations\AbstractMigration;
+
+/**
+ * Adding `score` field that can be specifically assigned for each record
+ * when the user submits the survey and it's either calculated automatically
+ * or reviewed manually
+ */
+class AddScoreToSurveyResults extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('survey_results');
+
+        $table->addColumn('score', 'integer', [
+            'default' => 0,
+            'null' => true,
+        ]);
+
+        $table->update();
+    }
+}

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -98,6 +98,7 @@ class SurveysController extends AppController
     public function view(?string $id)
     {
         $questionTypes = $this->SurveyQuestions->getQuestionTypes();
+        /** @var \Qobo\Survey\Model\Entity\Survey $survey */
         $survey = $this->Surveys->getSurveyData($id, true);
 
         //@TODO: offload it to API based dataTables call
@@ -318,7 +319,7 @@ class SurveysController extends AppController
     public function submit()
     {
         $this->request->allowMethod(['post', 'put', 'patch']);
-
+        $questions = [];
         $response = [
             'data' => [],
             'errors' => [],
@@ -332,11 +333,18 @@ class SurveysController extends AppController
             $questions = $data['SurveyResults'];
         }
 
+        if (empty($questions)) {
+            $this->Flash->error((string)__('No questions submitted to survey'));
+
+            return $this->redirect($this->referer());
+        }
+
         $entry = $this->SurveyEntries->newEntity();
         $this->SurveyEntries->patchEntity($entry, $data);
 
         $entry = $this->SurveyEntries->save($entry);
         Assert::isInstanceOf($entry, SurveyEntry::class);
+
 
         $saved = [];
         foreach ($questions as $k => $item) {

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -15,10 +15,10 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
 use Qobo\Survey\Controller\AppController;
+use Qobo\Survey\Event\EventName;
 use Qobo\Survey\Model\Entity\SurveyEntry;
 use Qobo\Survey\Model\Table\SurveyQuestionsTable;
 use Qobo\Survey\Model\Table\SurveyResultsTable;
-use Qobo\Survey\Event\EventName;
 use Webmozart\Assert\Assert;
 
 /**
@@ -374,7 +374,6 @@ class SurveysController extends AppController
         if (!empty($saved)) {
             $response['data'] = $saved;
             $response['status'] = true;
-
         }
 
         $this->set(compact('response'));

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -15,6 +15,9 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
 use Qobo\Survey\Controller\AppController;
+use Qobo\Survey\Model\Entity\SurveyEntry;
+use Qobo\Survey\Model\Table\SurveyQuestionsTable;
+use Qobo\Survey\Model\Table\SurveyResultsTable;
 use Qobo\Survey\Event\EventName;
 use Webmozart\Assert\Assert;
 
@@ -23,11 +26,16 @@ use Webmozart\Assert\Assert;
  *
  * @property \Qobo\Survey\Model\Table\SurveysTable $Surveys
  * @property \Qobo\Survey\Model\Table\SurveyAnswersTable $SurveyAnswers
+ * @property \Qobo\Survey\Model\Table\SurveyEntriesTable $SurveyEntries
+ * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable $SurveyQuestions
+ * @property \Qobo\Survey\Model\Table\SurveyResultsTable $SurveyResults
  *
  * @method \Qobo\Survey\Model\Entity\Survey[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
 class SurveysController extends AppController
 {
+    protected $SurveyEntries;
+
     protected $SurveyQuestions;
 
     protected $SurveyResults;
@@ -48,6 +56,10 @@ class SurveysController extends AppController
         /** @var \Qobo\Survey\Model\Table\SurveyResultsTable $SurveyResults */
         $table = TableRegistry::getTableLocator()->get('Qobo/Survey.SurveyResults');
         $this->SurveyResults = $table;
+
+        /** @var \Qobo\Survey\Model\Table\SurveyEntriesTable $SurveyEntries */
+        $table = TableRegistry::getTableLocator()->get('Qobo/Survey.SurveyEntries');
+        $this->SurveyEntries = $table;
     }
 
     /**
@@ -88,23 +100,15 @@ class SurveysController extends AppController
         $questionTypes = $this->SurveyQuestions->getQuestionTypes();
         $survey = $this->Surveys->getSurveyData($id, true);
 
-        $event = new Event((string)EventName::VIEW_SURVEY_RESULTS(), $this, [
-            'user' => $this->Auth->user(),
-            'survey' => $survey,
-            'data' => [],
-        ]);
+        //@TODO: offload it to API based dataTables call
+        $query = $this->SurveyEntries->find()
+            ->where([
+                'survey_id' => $survey->get('id')
+            ])
+            ->order(['submit_date' => 'DESC']);
+        $entries = $query->all();
 
-        $this->getEventManager()->dispatch($event);
-
-        if (!empty($event->result)) {
-            $submits = $event->result;
-        } else {
-            if (! empty($survey)) {
-                $submits = $this->SurveyResults->getSubmits($survey->get('id'));
-            }
-        }
-
-        $this->set(compact('survey', 'questionTypes', 'submits'));
+        $this->set(compact('survey', 'questionTypes', 'submits', 'entries'));
     }
 
     /**
@@ -168,43 +172,6 @@ class SurveysController extends AppController
         $survey = $this->Surveys->getSurveyData($id, true);
         Assert::isInstanceOf($survey, EntityInterface::class);
 
-        if ($this->request->is(['post', 'put', 'patch'])) {
-            $requestData = (array)$this->request->getData();
-
-            if (empty($requestData['SurveyResults'])) {
-                $this->Flash->error((string)__('Please submit your survey answers'));
-
-                return $this->redirect(['controller' => 'Surveys', 'action' => 'view', $id]);
-            }
-
-            foreach ($requestData['SurveyResults'] as $k => $item) {
-                $results = $this->SurveyResults->getResults($item, [
-                    'user' => $this->Auth->user(),
-                    'survey' => $survey,
-                    'data' => $requestData
-                ]);
-
-                $data = array_merge($data, $results);
-            }
-            foreach ($data as $k => $surveyResult) {
-                $saved[] = $this->SurveyResults->saveData($surveyResult);
-            }
-
-            $failed = array_filter($saved, function ($item) {
-                if (!$item['status']) {
-                    return $item;
-                }
-            });
-
-            if (empty($failed)) {
-                $this->Flash->success((string)__('Saved questionnaire results'));
-
-                return $this->redirect(['controller' => 'Surveys', 'action' => 'view', $id]);
-            } else {
-                $this->Flash->success((string)__('Some errors took place during result savings'));
-            }
-        }
-
         $this->set(compact('survey'));
     }
 
@@ -237,6 +204,7 @@ class SurveysController extends AppController
             return $this->redirect(['action' => 'view', $entity->get('id')]);
         }
     }
+
     /**
      * Add method
      *
@@ -340,5 +308,81 @@ class SurveysController extends AppController
         }
 
         $this->set(compact('survey', 'surveyResults'));
+    }
+
+    /**
+     * Submit action.
+     *
+     * @return \Cake\Http\Response|void|null
+     */
+    public function submit()
+    {
+        $this->request->allowMethod(['post', 'put', 'patch']);
+
+        $response = [
+            'data' => [],
+            'errors' => [],
+            'status' => false,
+        ];
+
+        $data = $this->request->getData();
+        Assert::isArray($data);
+
+        if (!empty($data['SurveyResults'])) {
+            $questions = $data['SurveyResults'];
+        }
+
+        $entry = $this->SurveyEntries->newEntity();
+        $this->SurveyEntries->patchEntity($entry, $data);
+
+        $entry = $this->SurveyEntries->save($entry);
+        Assert::isInstanceOf($entry, SurveyEntry::class);
+
+        $saved = [];
+        foreach ($questions as $k => $item) {
+            if (!is_array($item['survey_answer_id'])) {
+                $entity = $this->SurveyResults->newEntity();
+
+                $entity->set('submit_id', $entry->get('id'));
+                $entity->set('submit_date', $entry->get('submit_date'));
+                $entity->set('survey_id', $entry->get('survey_id'));
+                $entity->set('survey_question_id', $item['survey_question_id']);
+                $entity->set('result', (!empty($item['result']) ? $item['result'] : null));
+                $entity->set('survey_answer_id', $item['survey_answer_id']);
+                $result = $this->SurveyResults->save($entity);
+                if ($result) {
+                    $saved[] = $result;
+                }
+            } else {
+                foreach ($item['survey_answer_id'] as $answer) {
+                    $entity = $this->SurveyResults->newEntity();
+                    $entity->set('submit_id', $entry->get('id'));
+                    $entity->set('submit_date', $entry->get('submit_date'));
+                    $entity->set('survey_id', $entry->get('survey_id'));
+                    $entity->set('survey_question_id', $item['survey_question_id']);
+                    $entity->set('result', (!empty($item['result']) ? $item['result'] : null));
+                    $entity->set('survey_answer_id', $answer);
+                    $result = $this->SurveyResults->save($entity);
+
+                    if ($result) {
+                        $saved[] = $result;
+                    }
+                }
+            }
+        }
+
+        if (!empty($saved)) {
+            $response['data'] = $saved;
+            $response['status'] = true;
+
+        }
+
+        $this->set(compact('response'));
+        $this->set('_serialize', 'response');
+
+        //@FIXME: remove this redirect after refactoring
+        if (!$this->request->is('ajax')) {
+            return $this->redirect($this->referer());
+        }
     }
 }

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -345,7 +345,6 @@ class SurveysController extends AppController
         $entry = $this->SurveyEntries->save($entry);
         Assert::isInstanceOf($entry, SurveyEntry::class);
 
-
         $saved = [];
         foreach ($questions as $k => $item) {
             if (!is_array($item['survey_answer_id'])) {

--- a/src/Shell/SurveysShell.php
+++ b/src/Shell/SurveysShell.php
@@ -7,6 +7,8 @@ use Cake\Console\Shell;
  * Surveys shell command.
  *
  * @property \Qobo\Survey\Shell\Task\AddDefaultSectionsTask $AddDefaultSections
+ * @property \Qobo\Survey\Shell\Task\MoveSubmitsToEntriesTask $MoveSubmitsToEntries
+ * @property \Qobo\Survey\Shell\Task\MigrateScoresToSurveyResultsTask $MigrateScoresToSurveyResults
  */
 class SurveysShell extends Shell
 {

--- a/src/Shell/SurveysShell.php
+++ b/src/Shell/SurveysShell.php
@@ -13,6 +13,7 @@ class SurveysShell extends Shell
     public $tasks = [
         'Qobo/Survey.AddDefaultSections',
         'Qobo/Survey.MoveSubmitsToEntries',
+        'Qobo/Survey.MigrateScoresToSurveyResults'
     ];
     /**
      * Manage the available sub-commands along with their arguments and help
@@ -37,6 +38,12 @@ class SurveysShell extends Shell
                 [
                     'help' => 'Pre-populating Survey Entry with all the submits that took place',
                     'parser' => $this->MoveSubmitsToEntries->getOptionParser()
+                ]
+            )->addSubcommand(
+                'migrate_scores_to_survey_results',
+                [
+                    'help' => 'Migrate score values to survey_results records',
+                    'parser' => $this->MigrateScoresToSurveyResults->getOptionParser()
                 ]
             );
 

--- a/src/Shell/Task/MigrateScoresToSurveyResultsTask.php
+++ b/src/Shell/Task/MigrateScoresToSurveyResultsTask.php
@@ -1,0 +1,209 @@
+<?php
+namespace Qobo\Survey\Shell\Task;
+
+use Cake\Console\Shell;
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\TableRegistry;
+
+/**
+ * MigrateScoresToSurveyResults shell task.
+ *
+ *
+ *
+ * @property \Qobo\Survey\Model\Table\SurveyEntriesTable $SurveyEntries
+ * @property \Qobo\Survey\Model\Table\SurveyResultsTable $SurveyResults
+ */
+class MigrateScoresToSurveyResultsTask extends Shell
+{
+    public $SurveyEntries;
+
+    public $SurveyResults;
+
+    /**
+     * Manage the available sub-commands along with their arguments and help
+     *
+     * @see http://book.cakephp.org/3.0/en/console-and-shells.html#configuring-options-and-generating-help
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        return $parser;
+    }
+
+    /**
+     * Initialize all required task properties to complete the task
+     *
+     * @return void
+     */
+    public function init() : void
+    {
+        /** @var \Qobo\Survey\Model\Table\SurveyEntriesTable $table */
+        $table = TableRegistry::getTableLocator()->get('Qobo/Survey.SurveyEntries');
+        $this->SurveyEntries = $table;
+
+        $table = TableRegistry::getTableLocator()->get('Qobo/Survey.SurveyResults');
+        $this->SurveyResults = $table;
+    }
+
+    /**
+     * main() method.
+     *
+     * @return bool|int|null Success or error code.
+     */
+    public function main()
+    {
+        $this->info((string)__('Migrating the scores from existing survey_entries to survey_results'));
+
+        // preparing required properties for the migration
+        $this->init();
+
+        if (!$this->hasEntries()) {
+            $this->info((string)__('No Survey submits found. Exiting'));
+
+            return true;
+        }
+
+        $entries = $this->SurveyEntries->find()
+            ->where(['id' => 'e2032854-4870-49b5-af94-5375afb0e208'])
+            ->contain(['SurveyResults']);
+
+        foreach ($entries->all() as $entry) {
+            $tree = $this->getSurveyResultsTree($entry);
+
+            if (empty($tree)) {
+                $this->out(
+                    (string)__(
+                        'No tree information for survey entry [{0}]. Next..',
+                        $entry->get('id')
+                    )
+                );
+                continue;
+            }
+
+            /** @var string $entryId */
+            foreach ($tree as $entryId => $questions) {
+                foreach ($questions as $qId => $answers) {
+                    $status = $this->setSurveyResultsScore($entryId, $qId, $answers);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if survey entries are present in the table.
+     *
+     * @return bool $result if any found
+     */
+    protected function hasEntries() : bool
+    {
+        $query = $this->SurveyEntries->find();
+
+        $result = $query->count() ? true : false;
+
+        return $result;
+    }
+
+    /**
+     * To avoid overhead, we simply store key/value data in a submit tree,
+     * that will be easier to process.
+     *
+     * Tree Structure:
+     *  'survey_entry_id' => [
+     *    'survey_question_id' => [
+     *        'survey_answer_id' => score,
+     *        'survey_answer_id' => score
+     *     ]
+     *     ...
+     *  ]
+     *
+     * @param \Cake\Datasource\EntityInterface $entry of the survey_entries instance
+     *
+     * @return mixed[] $data array containing survey_results tree.
+     */
+    protected function getSurveyResultsTree(EntityInterface $entry) : array
+    {
+        $data = [];
+        $submit = $this->SurveyResults->find()
+            ->where([
+                'submit_id' => $entry->get('id')
+            ])
+            ->contain(['SurveyQuestions', 'SurveyAnswers']);
+
+        if (empty($submit->count())) {
+            return $data;
+        }
+
+        $entryId = $entry->get('id');
+
+        foreach ($submit as $item) {
+            $question = $item->get('survey_question');
+            $answer = $item->get('survey_answer');
+
+            $qId = $question->get('id');
+            $aId = $answer->get('id');
+            $score = $answer->get('score');
+
+            if (!isset($data[$entryId][$qId])) {
+                $data[$entryId][$qId] = [];
+            }
+
+            $data[$entryId][$qId] = array_merge($data[$entryId][$qId], [$aId => $score]);
+        }
+
+        return $data;
+    }
+
+    /**
+     *  Update Score fields of each survey_results entry
+     *
+     * @param string $entryId of the survey_entries table
+     * @param string $questionId of the survey_questions table
+     * @param mixed[] $answers that contain key/value store of `answer_id` => `score` values
+     *
+     * @return bool $result
+     */
+    protected function setSurveyResultsScore(string $entryId, string $questionId, array $answers = []) : bool
+    {
+        $result = false;
+
+        if (empty($answers)) {
+            return $result;
+        }
+
+        $query = $this->SurveyResults->find()
+            ->where([
+                'submit_id' => $entryId,
+                'survey_question_id' => $questionId,
+                'survey_answer_id IN' => array_keys($answers),
+            ]);
+
+        if (!$query->count()) {
+            return $result;
+        }
+
+        foreach ($query as $item) {
+            $aId = $item->get('survey_answer_id');
+
+            $item->set('score', $answers[$aId]);
+            $saved = $this->SurveyResults->save($item);
+
+            if ($saved) {
+                $result = true;
+            } else {
+                $this->warn(
+                    (string)__(
+                        "Entry [{0}] Result ID: [{1}]: Couldn't update score for Question [{2}]. Answer ID [{3}]",
+                        $entryId,
+                        $item->get('id'),
+                        $questionId,
+                        $aId
+                    )
+                );
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Shell/Task/MigrateScoresToSurveyResultsTask.php
+++ b/src/Shell/Task/MigrateScoresToSurveyResultsTask.php
@@ -66,10 +66,9 @@ class MigrateScoresToSurveyResultsTask extends Shell
         }
 
         $entries = $this->SurveyEntries->find()
-            ->where(['id' => 'e2032854-4870-49b5-af94-5375afb0e208'])
             ->contain(['SurveyResults']);
 
-        foreach ($entries->all() as $entry) {
+        foreach ($entries as $entry) {
             $tree = $this->getSurveyResultsTree($entry);
 
             if (empty($tree)) {

--- a/src/Shell/Task/MoveSubmitsToEntriesTask.php
+++ b/src/Shell/Task/MoveSubmitsToEntriesTask.php
@@ -64,8 +64,6 @@ class MoveSubmitsToEntriesTask extends Shell
 
                 if ($saved) {
                     $count++;
-                } else {
-                    $this->out(print_r($entry->getErrors(), 1));
                 }
             }
         }

--- a/src/Template/Element/SurveyEntries/view.ctp
+++ b/src/Template/Element/SurveyEntries/view.ctp
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+use Cake\Core\Configure;
+
+$surveyId = !empty($survey->slug) ? $survey->slug : $survey->id;
+$statuses = Configure::read('Survey.Options.statuses');
+?>
+<div class="row">
+    <div class="col-xs-12 col-md-12">
+        <div class="pull-right">
+            <div class="btn-group btn-group-sm" role="group">
+                <?php if (empty($survey->publish_date)) : ?>
+                    <?= $this->Html->link(
+                        '<i class="fa fa-plus"></i> ' . __('Add Submit'),
+                        ['controller' => 'Surveys', 'action' => 'preview', $surveyId],
+                        ['class' => 'btn btn-default', 'escape' => false]
+                    )?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>
+<table class="table table-hover table-condensed table-vertical-align table-datatable" width="100%">
+    <thead>
+        <tr>
+            <th scope="col"><?= __('Origin') ?> </th>
+            <th scope="col"><?= __('Status') ?></th>
+            <th scope="col"><?= __('Grade') ?></th>
+            <th scope="col"><?= __('Submit Date') ?></th>
+            <th scope="col" class="actions"><?= __('Actions') ?></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($entries as $item) : ?>
+            <?php
+                $resourceUser = $item->get('resource_user');
+
+                if (!empty($resourceUser)) {
+                    $resourceUrl = $this->Html->link($resourceUser['displayField'], $resourceUser['url']);
+                }
+            ?>
+             <tr>
+                <td><?= $resourceUrl ?></td>
+                <td><?= in_array($item->get('status'), array_keys($statuses)) ? $statuses[$item->get('status')] : $item->get('status') ?></td>
+                <td><?= h($item->get('grade')) ?></td>
+                <td><?= h($item->get('submit_date')->i18nFormat('yyyy-MM-dd HH:mm:ss')) ?></td>
+                <td class="actions">
+                    <div class="btn-group btn-group-xs">
+                        <?= $this->Html->link('<i class="fa fa-eye"></i>', ['controller' => 'SurveyEntries', 'action' => 'view', $item->get('id')], ['escape' => false, 'class' => 'btn btn-default']) ?>
+                    </div>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>

--- a/src/Template/SurveyEntries/view.ctp
+++ b/src/Template/SurveyEntries/view.ctp
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+$surveyId = !empty($survey->slug) ? $survey->slug : $survey->id;
+
+$resourceUser = $surveyEntry->get('resource_user');
+
+$options['title'] = __(
+    '{0} &raquo; {1} &raquo; {2}',
+    $this->Html->link(__('Surveys'), ['controller' => 'Surveys', 'action' => 'index']),
+    $this->Html->link($survey->get('name'), ['controller' => 'Surveys', 'action' => 'view', $surveyId]),
+    __('Submit at "{0}" by "{1}"', $surveyEntry->get('submit_date')->i18nFormat('yyyy-MM-dd HH:mm'), $resourceUser['displayField'])
+);
+?>
+<section class="content-header">
+    <div class="row">
+        <div class="col-xs-12 col-md-6">
+            <h4><?= $options['title'] ?></h4>
+        </div>
+        <div class="col-xs-12 col-md-6">
+            <div class="pull-right">
+            <div class="btn-group btn-group-sm" role="group">
+                <?= $this->Form->postLink(
+                    '<i class="fa fa-trash"></i> ' . __('Delete'),
+                    ['plugin' => 'Qobo/Survey', 'controller' => 'SurveyEntries', 'action' => 'delete', $surveyEntry->get('id')],
+                    ['escape' => false, 'class' => 'btn btn-default', 'confirm' => __('Are you sure you want to delete # {0}', $survey->name)]
+                ); ?>
+            </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="content">
+    <?php $key = 0; ?>
+     <?php foreach ($survey->get('survey_sections') as $section) : ?>
+         <?php foreach ($section->get('survey_questions') as $question) : ?>
+                 <div class="box box-info">
+                     <div class="box-header with-border">
+                         <h3 class="box-title <?= $question->get('is_required') ? 'required' : '' ?>">
+                             <?= $question->get('question');?>
+                             <label></label>
+                         </h3>
+                     </div>
+                     <div class="box-body">
+                         <?= $this->element('Qobo/Survey.Answers/' . $question->get('type'), ['entity' => $question, 'key' => $key, 'collapsed' => false, 'entry' => $surveyEntry]);?>
+                     </div>
+                     <div class="box-footer">
+                         <div class="row">
+                             <div class="col-md-6">
+                                 <strong><?= __('Question Score: {0}', $this->Survey->getQuestionScore($question, $surveyEntry->get('id'))) ?></strong>
+                             </div>
+                             <div class="col-md-6">
+                                 <div class="pull-right">
+                                     <?= $this->Html->link(
+                                         (string)__('Review Grade'),
+                                         [
+                                             'controller' => 'SurveyEntries',
+                                             'action' => 'review',
+                                             $surveyEntry->get('id'),
+                                             $question->get('id')
+                                         ],
+                                         [
+                                             'class' => 'btn btn-sm btn-warning'
+                                         ]
+                                     ) ?>
+                                 </div>
+                             </div>
+                         </div>
+                     </div>
+                 </div>
+         <?php $key++; ?>
+         <?php endforeach; ?>
+     <?php endforeach; ?>
+</section>

--- a/src/Template/Surveys/preview.ctp
+++ b/src/Template/Surveys/preview.ctp
@@ -33,7 +33,7 @@ $count = 1;
 
 <section class="content">
     <?php
-        echo $this->Form->create($survey, ['url' => ['action' => 'preview']]);
+        echo $this->Form->create($survey, ['url' => ['action' => 'submit']]);
         echo $this->Form->hidden('SurveyEntries.survey_id', ['value' => $survey->get('id')]);
         echo $this->Form->hidden('SurveyEntries.submit_date', ['value' => date('Y-m-d H:i:s', time())]);
 

--- a/src/Template/Surveys/preview.ctp
+++ b/src/Template/Surveys/preview.ctp
@@ -12,6 +12,7 @@
 use Cake\Core\Configure;
 use Cake\Utility\Text;
 
+$userId = $this->request->getSession()->read('Auth.User.id');
 $surveyId = empty($survey->get('slug')) ? $survey->get('id') : $survey->get('slug');
 
 $options['title'] = __(
@@ -27,65 +28,75 @@ $count = 1;
         <div class="col-xs-12 col-md-6">
             <h4><?= $options['title'] ?></h4>
         </div>
-        <div class="col-xs-12 col-md-6">
-            <div class="pull-right">
-            <div class="btn-group btn-group-sm" role="group">
-            </div>
-            </div>
-        </div>
     </div>
 </section>
 
 <section class="content">
-<?= $this->Form->create($survey); ?>
-<?= $this->Form->hidden('submit_id', ['value' => Text::uuid()]) ?>
-<?= $this->Form->hidden('submit_date', ['value' => date('Y-m-d H:i:s', time())]) ?>
-<div class="box-group" id="accordion">
-<?php foreach ($survey->get('survey_sections') as $k => $section) :?>
-<?php
-    if (! count($section->get('survey_questions'))) {
-        continue;
-    }
-?>
-<div class="panel box box-primary">
-    <div class="box-header with-border">
-        <h4 class="box-title">
-            <?= $this->Html->link(
-                $section->get('name'),
-                '#'. $section->get('id'),
-                [
-                    'data-toggle' => 'collapse',
-                    'data-parent' => '#accordion',
-                    'aria-expanded' => 'false',
-                ]
-            ) ?>
-        </h4>
-    </div>
-    <div id="<?= $section->get('id')?>" class="panel-collapse collapse <?= ($k == 0) ? 'in' : '' ?>" aria-expanded="true">
-        <div class="box-body">
-            <?php foreach ($section->get('survey_questions') as $k => $question) : ?>
-                <div class="box box-solid">
-                    <div class="box-header with-border">
-                        <h3 class="box-title"><?= $count ?>. <?= $question->get('question');?></h3>
-                        <div class="box-tools pull-right">
-                            <button type="button" class="btn btn-box-tool" data-widget="collapse">
-                                <i class="fa fa-minus"></i>
-                            </button>
+    <?php
+        echo $this->Form->create($survey, ['url' => ['action' => 'preview']]);
+        echo $this->Form->hidden('SurveyEntries.survey_id', ['value' => $survey->get('id')]);
+        echo $this->Form->hidden('SurveyEntries.submit_date', ['value' => date('Y-m-d H:i:s', time())]);
+
+        /** $user variable derives from AppController of application */
+        echo $this->Form->hidden('SurveyEntries.resource_id', ['value' => $userId]);
+        echo $this->Form->hidden('SurveyEntries.resource', ['value' => 'Users']);
+    ?>
+
+    <div class="nav-tabs-custom">
+
+        <ul class="nav nav-tabs">
+        <?php foreach ($survey->get('survey_sections') as $k => $section) : ?>
+           <?php
+               if (! count($section->get('survey_questions'))) {
+                   continue;
+               }
+           ?>
+           <li class="<?= $k == 0 ? 'active' : ''?>">
+               <?= $this->Html->link(
+                   $count . '. ' . $section->get('name'),
+                   '#'. $section->get('id'),
+                   [
+                       'data-toggle' => 'tab',
+                       'aria-expanded' => 'true'
+                   ]
+                ) ?>
+           </li>
+        <?php $count++; ?>
+        <?php endforeach; ?>
+        </ul>
+        <?php $count = 0; ?>
+        <?php $qcount = 1; ?>
+        <div class="tab-content">
+            <?php foreach ($survey->get('survey_sections') as $k => $section) :?>
+            <?php
+                if (! count($section->get('survey_questions'))) {
+                    continue;
+                }
+            ?>
+            <div class="tab-pane <?= $k == 0 ? 'active' : '' ?>" id="<?= $section->get('id') ?>">
+                <?php foreach ($section->get('survey_questions') as $k => $question) : ?>
+                    <div class="box box-solid">
+                        <div class="box-header with-border">
+                            <h3 class="box-title <?= $question->get('is_required') ? 'required' : '' ?>">
+                                <?= $qcount ?>. <?= $question->get('question');?>
+                                <label></label>
+                            </h3>
+                        </div>
+                        <div class="box-body">
+                            <?= $this->element('Qobo/Survey.Answers/' . $question->get('type'), ['entity' => $question, 'key' => $count, 'collapsed' => false]);?>
                         </div>
                     </div>
-                    <div class="box-body">
-                        <?= $this->element('Qobo/Survey.Answers/' . $question->type, ['entity' => $question, 'key' => $k, 'collapsed' => false]);?>
-                    </div>
-                </div>
+                <?php $qcount++; ?>
+                <?php $count++; ?>
+                <?php endforeach; ?>
+            </div>
+
             <?php endforeach; ?>
         </div>
     </div>
-</div>
 
-<?php endforeach; ?>
-</div>
-<?php if (Configure::read('Survey.Options.submitViaPreview')) : ?>
-    <?= $this->Form->submit(__('Submit')); ?>
-<?php endif; ?>
-<?= $this->Form->end();?>
+    <?php if (Configure::read('Survey.Options.submitViaPreview')) : ?>
+        <?= $this->Form->submit(__('Submit')); ?>
+    <?php endif; ?>
+    <?= $this->Form->end();?>
 </section>

--- a/src/Template/Surveys/view.ctp
+++ b/src/Template/Surveys/view.ctp
@@ -160,32 +160,30 @@ $options['title'] = __(
     <div class="nav-tabs-custom">
         <ul id="relatedTabs" class="nav nav-tabs" role="tablist">
             <li role="presentation">
+                <a href="#manage-survey-results" aria-controls="manage-survey-results" role="tab" data-toggle="tab">
+                    <i class="fa fa-check-circle"></i> <?= __('Overview') ?>
+                </a>
+            </li>
+            <li role="presentation">
                 <a href="#manage-survey-sections" aria-controls="manage-content" role="tab" data-toggle="tab">
                     <i class="fa fa-list-ul"></i> <i class="fa question-circle"></i> <?= __('Sections'); ?>
                 </a>
             </li>
             <li role="presentation">
-                <a href="#manage-survey-results" aria-controls="manage-survey-results" role="tab" data-toggle="tab">
-                    <i class="fa fa-check-circle"></i> <?= __('Overview'); ?>
-                </a>
-            </li>
-            <li role="presentation">
-                <a href="#manage-survey-submits" aria-controls="manage-survey-submits" role="tab" data-toggle="tab">
-                    <i class="fa fa-signal"></i> <?= __('Results'); ?>
+                <a href="#manage-survey-entries" aria-controls="manager-survey-entries" role="tab" data-toggle="tab">
+                    <i class="fa fa-signal"></i> <?= __('Entries') ?>
                 </a>
             </li>
         </ul>
         <div class="tab-content">
-            <div role="tabpanel" class="tab-pane" id="manage-survey-sections">
-                <?= $this->element('Qobo/Survey.SurveySections/view', ['survey' => $survey]); ?>
-            </div>
             <div role="tabpanel" class="tab-pane" id="manage-survey-results">
-                <?= $this->element('Qobo/Survey.SurveyResults/view', ['survey' => $survey]); ?>
+                <?= $this->element('Qobo/Survey.SurveyResults/view', ['survey' => $survey]) ?>
             </div>
-            <div role="tabpanel" class="tab-pane" id="manage-survey-submits">
-                <?php if (!empty($submits)) : ?>
-                    <?= $this->element('Qobo/Survey.SurveyResults/submits', ['submits' => $submits]); ?>
-                <?php endif; ?>
+            <div role="tabpanel" class="tab-pane" id="manage-survey-sections">
+                <?= $this->element('Qobo/Survey.SurveySections/view', ['survey' => $survey]) ?>
+            </div>
+            <div role="tabpanel" class="tab-pane" id="manage-survey-entries">
+                <?= $this->element('Qobo/Survey.SurveyEntries/view', ['survey' => $survey]) ?>
             </div>
         </div>
     </div>

--- a/tests/TestCase/Controller/SurveysControllerTest.php
+++ b/tests/TestCase/Controller/SurveysControllerTest.php
@@ -111,7 +111,6 @@ class SurveysControllerTest extends IntegrationTestCase
     {
         $surveyId = '00000000-0000-0000-0000-000000000001';
         $this->get('/surveys/surveys/preview/' . $surveyId);
-
         $this->assertResponseOk();
     }
 
@@ -265,8 +264,10 @@ class SurveysControllerTest extends IntegrationTestCase
         $this->assertSession('Expiry date should be bigger than publish date', 'Flash.flash.0.message');
     }
 
+    // @TODO: Given test doesn't/won't reflect current preview behaviour
     public function testPreviewPost(): void
     {
+        $this->markTestSkipped((string)__('This test needs refactoring as part of separate PR'));
         $query = $this->Surveys->find()
             ->limit(1);
         /**

--- a/tests/TestCase/Controller/SurveysControllerTest.php
+++ b/tests/TestCase/Controller/SurveysControllerTest.php
@@ -14,6 +14,7 @@ class SurveysControllerTest extends IntegrationTestCase
         'plugin.qobo/survey.survey_results',
         'plugin.qobo/survey.survey_questions',
         'plugin.qobo/survey.survey_answers',
+        'plugin.qobo/survey.survey_entries',
         'plugin.qobo/survey.survey_sections',
         'plugin.qobo/survey.surveys',
         'plugin.qobo/survey.users',

--- a/tests/TestCase/Model/Table/SurveyEntriesTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyEntriesTableTest.php
@@ -38,7 +38,9 @@ class SurveyEntriesTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::getTableLocator()->exists('SurveyEntries') ? [] : ['className' => SurveyEntriesTable::class];
-        $this->SurveyEntries = TableRegistry::getTableLocator()->get('SurveyEntries', $config);
+        /** @var \Qobo\Survey\Model\Table\SurveyEntriesTable $table */
+        $table = TableRegistry::getTableLocator()->get('SurveyEntries', $config);
+        $this->SurveyEntries = $table;
     }
 
     /**
@@ -58,7 +60,7 @@ class SurveyEntriesTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize() : void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
@@ -68,7 +70,7 @@ class SurveyEntriesTableTest extends TestCase
      *
      * @return void
      */
-    public function testValidationDefault()
+    public function testValidationDefault() : void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
@@ -78,7 +80,7 @@ class SurveyEntriesTableTest extends TestCase
      *
      * @return void
      */
-    public function testBuildRules()
+    public function testBuildRules() : void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }


### PR DESCRIPTION
It's one of the upcoming improvements in surveys functionality that will precede final `survey_entries` functionality.

In order to have full control over scoring procedure, `survey_results` will store each score in its corresponding record, so the user will be able to invalidate/re-calculate particular question, if the system incorrectly calculated the total score.