### PR TITLE
Adding SurveyEntryQuestion entity (Task #13087)

### DIFF
--- a/config/Migrations/20190830092142_CreateSurveyEntryQuestions.php
+++ b/config/Migrations/20190830092142_CreateSurveyEntryQuestions.php
@@ -1,0 +1,63 @@
+<?php
+use Migrations\AbstractMigration;
+
+class CreateSurveyEntryQuestions extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('survey_entry_questions', ['id' => false, 'primary_key' => ['id']]);
+
+        $table->addColumn('id', 'uuid', [
+            'default' => null,
+            'null' => false,
+        ]);
+
+        $table->addColumn('survey_entry_id', 'uuid', [
+            'default' => null,
+            'null' => false,
+        ]);
+
+        $table->addColumn('survey_question_id', 'uuid', [
+            'default' => null,
+            'null' => false,
+        ]);
+
+        $table->addColumn('status', 'string', [
+            'default' => 'null',
+            'null' => true,
+        ]);
+
+        $table->addColumn('score', 'integer', [
+            'default' => 0,
+            'null' => true,
+        ]);
+
+        $table->addColumn('created', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+
+        $table->addColumn('modified', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+
+        $table->addColumn('trashed', 'datetime', [
+            'default' => null,
+            'null' => true,
+        ]);
+
+        $table->addPrimaryKey([
+            'id',
+        ]);
+
+        $table->create();
+    }
+}

--- a/config/Migrations/20190830093733_AddEntryQuestionToSurveyResults.php
+++ b/config/Migrations/20190830093733_AddEntryQuestionToSurveyResults.php
@@ -1,0 +1,23 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddEntryQuestionToSurveyResults extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('survey_results');
+        $table->addColumn('survey_entry_question_id', 'uuid', [
+            'default' => null,
+            'null' => true,
+        ]);
+
+        $table->update();
+    }
+}


### PR DESCRIPTION
`SurveyEntryQuestion` will allow us to simplify the functionality for the following matters:

* Decouple time-series data in case the answers score changes over time 
* EntryQuestion record will store actual status of the question submitted (no need to keep it in multiple question results submitted). This will avoid code complexity.
* Better `score` storage of each question per entry.