### PR TITLE
splitting edit and view for roles-capabilities

### DIFF
--- a/src/Controller/SurveyEntriesController.php
+++ b/src/Controller/SurveyEntriesController.php
@@ -80,6 +80,41 @@ class SurveyEntriesController extends AppController
                 ]
             )->first();
 
+        $this->set(compact('surveyEntry', 'survey', 'entryStatuses'));
+    }
+
+    /**
+     * Edit method
+     *
+     * @param string $id Survey Entry id.
+     * @return \Cake\Http\Response|void|null
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function edit(string $id)
+    {
+        $entryStatuses = $this->SurveyEntries->getStatuses();
+        $surveyEntry = $this->SurveyEntries->get($id, [
+            'contain' => [
+                'SurveyEntryQuestions' =>
+                [
+                    'SurveyQuestions' => 'SurveyAnswers',
+                    'SurveyResults'
+                ]
+            ],
+        ]);
+
+        $survey = $this->Surveys->find()
+            ->where([
+                'id' => $surveyEntry->get('survey_id')
+            ])
+            ->contain(
+                [
+                    'SurveySections' => [
+                        'SurveyQuestions' => 'SurveyAnswers'
+                    ]
+                ]
+            )->first();
+
         if ($this->request->is(['post', 'put', 'patch'])) {
             $data = (array)$this->request->getData();
             if (!empty($data['SurveyEntryQuestions'])) {
@@ -125,31 +160,6 @@ class SurveyEntriesController extends AppController
         }
 
         $this->set(compact('surveyEntry', 'survey', 'entryStatuses'));
-    }
-
-    /**
-     * Edit method
-     *
-     * @param string $id Survey Entry id.
-     * @return \Cake\Http\Response|void|null Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
-     */
-    public function edit(string $id)
-    {
-        $surveyEntry = $this->SurveyEntries->get($id);
-
-        if ($this->request->is(['patch', 'post', 'put'])) {
-            $surveyEntry = $this->SurveyEntries->patchEntity($surveyEntry, (array)$this->request->getData());
-            if ($this->SurveyEntries->save($surveyEntry)) {
-                $this->Flash->success((string)__('The survey entry has been saved.'));
-
-                return $this->redirect(['action' => 'index']);
-            }
-            $this->Flash->error((string)__('The survey entry could not be saved. Please, try again.'));
-        }
-        $surveys = $this->SurveyEntries->Surveys->find('list');
-
-        $this->set(compact('surveyEntry', 'surveys'));
     }
 
     /**

--- a/src/Template/Element/SurveyEntries/view.ctp
+++ b/src/Template/Element/SurveyEntries/view.ctp
@@ -56,6 +56,7 @@ $statuses = Configure::read('Survey.Options.statuses');
                 <td class="actions">
                     <div class="btn-group btn-group-xs">
                         <?= $this->Html->link('<i class="fa fa-eye"></i>', ['controller' => 'SurveyEntries', 'action' => 'view', $item->get('id')], ['escape' => false, 'class' => 'btn btn-default']) ?>
+                        <?= $this->Html->link('<i class="fa fa-pencil"></i>', ['controller' => 'SurveyEntries', 'action' => 'edit', $item->get('id')], ['escape' => false, 'class' => 'btn btn-default']) ?>
                     </div>
                 </td>
             </tr>

--- a/src/Template/SurveyEntries/view.ctp
+++ b/src/Template/SurveyEntries/view.ctp
@@ -44,7 +44,6 @@ $entryStatuses = Configure::read('Survey.Options.statuses');
 </section>
 
 <section class="content">
-    <?= $this->Form->create() ?>
     <?= $this->Form->hidden('SurveyEntries.id', ['value' => $surveyEntry->get('id')]) ?>
     <?= $this->Form->hidden('SurveyEntries.survey_id', ['value' => $survey->get('id')]) ?>
 
@@ -57,17 +56,9 @@ $entryStatuses = Configure::read('Survey.Options.statuses');
             </div>
             <div class="row">
                 <div class="col-xs-12 col-md-6">
-                    <?= $this->Form->control(
-                        'SurveyEntries.status',
-                        [
-                            'options' => $entryStatuses,
-                            'value' => $surveyEntry->get('status'),
-                            'empty' => __('Choose Survey status')
-                        ]
-                    ) ?>
+                    <h4><?= __('Current Status: {0}', $entryStatuses[$surveyEntry->get('status')]) ?></h4>
                 </div>
             </div>
-            <?= $this->Form->button(__('Save'), ['class' => 'btn btn-success']) ?>
         </div>
     </div>
 
@@ -88,22 +79,4 @@ $entryStatuses = Configure::read('Survey.Options.statuses');
             <?php $count++; ?>
         <?php endforeach;?>
     <?php endforeach;?>
-    <div class="box">
-        <div class="box-body">
-            <div class="row">
-                <div class="col-xs-12 col-md-6">
-                    <?= $this->Form->control(
-                        'SurveyEntries.status',
-                        [
-                            'options' => $entryStatuses,
-                            'value' => $surveyEntry->get('status'),
-                            'empty' => __('Choose Survey status')
-                        ]
-                    ) ?>
-                </div>
-            </div>
-            <?= $this->Form->button(__('Save'), ['class' => 'btn btn-success']) ?>
-        </div>
-    </div>
-    <?= $this->Form->end() ?>
 </section>


### PR DESCRIPTION
To comply with `qobo/cakephp-roles-capabilities` plugin editing of SurveyEntries is now split to `edit` method, keeping `view.ctp` only for read-only purposes.