### PR TITLE
Allow Surveys to work with passthrough entity IDs

### DIFF
--- a/src/Model/Entity/SectionsQuestion.php
+++ b/src/Model/Entity/SectionsQuestion.php
@@ -30,6 +30,5 @@ class SectionsQuestion extends Entity
      */
     protected $_accessible = [
         '*' => true,
-        'id' => false,
     ];
 }

--- a/src/Model/Entity/Survey.php
+++ b/src/Model/Entity/Survey.php
@@ -42,7 +42,6 @@ class Survey extends Entity
      * @var array
      */
     protected $_accessible = [
-        '*' => true,
-        'id' => false,
+        '*' => true
     ];
 }

--- a/src/Model/Entity/SurveyAnswer.php
+++ b/src/Model/Entity/SurveyAnswer.php
@@ -39,7 +39,6 @@ class SurveyAnswer extends Entity
      * @var array
      */
     protected $_accessible = [
-        '*' => true,
-        'id' => false,
+        '*' => true
     ];
 }

--- a/src/Model/Entity/SurveyEntry.php
+++ b/src/Model/Entity/SurveyEntry.php
@@ -38,7 +38,6 @@ class SurveyEntry extends Entity
      */
     protected $_accessible = [
         '*' => true,
-        'id' => false,
     ];
 
     /**

--- a/src/Model/Entity/SurveyEntryQuestion.php
+++ b/src/Model/Entity/SurveyEntryQuestion.php
@@ -32,7 +32,6 @@ class SurveyEntryQuestion extends Entity
      */
     protected $_accessible = [
         '*' => true,
-        'id' => false,
     ];
 
     /**

--- a/src/Model/Entity/SurveyQuestion.php
+++ b/src/Model/Entity/SurveyQuestion.php
@@ -46,7 +46,6 @@ class SurveyQuestion extends Entity
      */
     protected $_accessible = [
         '*' => true,
-        'id' => false,
     ];
 
     /**

--- a/src/Model/Entity/SurveyResult.php
+++ b/src/Model/Entity/SurveyResult.php
@@ -44,7 +44,6 @@ class SurveyResult extends Entity
      * @var array
      */
     protected $_accessible = [
-        '*' => true,
-        'id' => false,
+        '*' => true
     ];
 }

--- a/src/Model/Entity/SurveySection.php
+++ b/src/Model/Entity/SurveySection.php
@@ -29,7 +29,6 @@ class SurveySection extends Entity
      * @var array
      */
     protected $_accessible = [
-        '*' => true,
-        'id' => false,
+        '*' => true
     ];
 }

--- a/src/Model/Table/SurveyEntryQuestionsTable.php
+++ b/src/Model/Table/SurveyEntryQuestionsTable.php
@@ -98,7 +98,7 @@ class SurveyEntryQuestionsTable extends Table
      */
     public function buildRules(RulesChecker $rules)
     {
-        // $rules->add($rules->existsIn('survey_entry_id', 'SurveyEntries'));
+        $rules->add($rules->existsIn('survey_entry_id', 'SurveyEntries'));
         $rules->add($rules->existsIn('survey_question_id', 'SurveyQuestions'));
 
         return $rules;

--- a/src/Model/Table/SurveyEntryQuestionsTable.php
+++ b/src/Model/Table/SurveyEntryQuestionsTable.php
@@ -41,6 +41,7 @@ class SurveyEntryQuestionsTable extends Table
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('Muffin/Trash.Trash');
 
         $this->belongsTo('SurveyEntries', [
             'foreignKey' => 'survey_entry_id',
@@ -97,8 +98,8 @@ class SurveyEntryQuestionsTable extends Table
      */
     public function buildRules(RulesChecker $rules)
     {
-        $rules->add($rules->existsIn(['survey_entry_id'], 'SurveyEntries'));
-        $rules->add($rules->existsIn(['survey_question_id'], 'SurveyQuestions'));
+        // $rules->add($rules->existsIn('survey_entry_id', 'SurveyEntries'));
+        $rules->add($rules->existsIn('survey_question_id', 'SurveyQuestions'));
 
         return $rules;
     }

--- a/src/Model/Table/SurveyResultsTable.php
+++ b/src/Model/Table/SurveyResultsTable.php
@@ -249,10 +249,11 @@ class SurveyResultsTable extends Table
      * @param \Qobo\Survey\Model\Entity\SurveyEntry $entry instance
      * @param mixed[] $data with post data
      * @param \Qobo\Survey\Model\Entity\SurveyEntryQuestion $questionEntry instance
+     * @param mixed[] $options for entity options
      *
      * @return \Qobo\Survey\Model\Entity\SurveyResult|bool $result
      */
-    public function saveResultsEntity(SurveyEntry $entry, array $data, SurveyEntryQuestion $questionEntry)
+    public function saveResultsEntity(SurveyEntry $entry, array $data, SurveyEntryQuestion $questionEntry, array $options = [])
     {
         $result = false;
         $score = 0;
@@ -272,7 +273,11 @@ class SurveyResultsTable extends Table
         Assert::isInstanceOf($answerEntity, EntityInterface::class);
         $score = $answerEntity->get('score');
 
-        $entity = $this->newEntity();
+        $entity = $this->newEntity(null, $options);
+
+        if (!empty($data['id']) && !empty($options['accessibleFields'])) {
+            $entity->set('id', $data['id']);
+        }
 
         $entity->set('survey_entry_question_id', $questionEntry->get('id'));
         $entity->set('survey_question_id', $questionEntry->get('survey_question_id'));


### PR DESCRIPTION
- Allow using existing IDs for `uuid` fields, in case the system keeps them unique throughout the system.