### PR TITLE
Move survey publish event inside afterSave event

### DIFF
--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -135,7 +135,7 @@ class SurveysController extends AppController
         Assert::isInstanceOf($survey, EntityInterface::class);
 
         if ($this->request->is(['post', 'put', 'patch'])) {
-            $validated = $this->Surveys->prepublishValidate($id, $this->request);
+            $validated = $this->Surveys->prepublishValidate($id, $this->getRequest());
             if (false === $validated['status']) {
                 $this->Flash->error(implode("\r\n", $validated['errors']), ['escape' => false]);
 

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -131,7 +131,7 @@ class SurveysController extends AppController
      */
     public function publish(string $id)
     {
-        $survey = $this->Surveys->getSurveyData($id);
+        $survey = $this->Surveys->get($id);
         Assert::isInstanceOf($survey, EntityInterface::class);
 
         if ($this->request->is(['post', 'put', 'patch'])) {
@@ -143,24 +143,13 @@ class SurveysController extends AppController
             }
 
             $data = $this->request->getData();
-            $survey = $this->Surveys->patchEntity($survey, (array)$data, ['validate' => false]);
+            $survey = $this->Surveys->patchEntity($survey, (array)$data);
 
-            if ($this->Surveys->save($survey)) {
-                $this->Flash->success((string)__('Survey was successfully saved.'));
-
-                $fullSurvey = $this->Surveys->getSurveyData($survey->get('id'), true);
-
-                $event = new Event((string)EventName::PUBLISH_SURVEY(), $this, [
-                    'data' => [
-                        'action' => 'add_survey',
-                        'survey' => $fullSurvey,
-                    ]
-                ]);
-                $this->getEventManager()->dispatch($event);
+            if ($this->Surveys->save($survey, ['publishSurvey' => true])) {
+                $this->Flash->success((string)__('Survey was successfully published.'));
 
                 return $this->redirect(['action' => 'view', $id]);
             }
-
             $this->Flash->error((string)__('Couldn\'t publish the survey'));
         }
 

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -134,11 +134,6 @@ class SurveysController extends AppController
         $survey = $this->Surveys->getSurveyData($id);
         Assert::isInstanceOf($survey, EntityInterface::class);
 
-        // Fix for existing copied surveys
-        if (empty($survey->get('publish_date'))) {
-            $survey->set('expiry_date', null);
-        }
-
         if ($this->request->is(['post', 'put', 'patch'])) {
             $validated = $this->Surveys->prepublishValidate($id, $this->request);
             if (false === $validated['status']) {

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -65,7 +65,7 @@ class SurveysTable extends Table
         $this->addBehavior('Duplicatable.Duplicatable', [
             'finder' => 'all',
             'contain' => ['SurveySections.SurveyQuestions.SurveyAnswers'],
-            'remove' => ['publish_date', 'created', 'modified', 'slug'],
+            'remove' => ['publish_date', 'created', 'modified', 'slug', 'expiry_date'],
             'append' => [
                 'name' => ' - (duplicated: ' . date('Y-m-d H:i', time()) . ')',
             ]

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -22,6 +22,7 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Validation\Validator;
+use Qobo\Survey\Event\EventName;
 use Webmozart\Assert\Assert;
 
 /**
@@ -162,6 +163,17 @@ class SurveysTable extends Table
             if (! $query->count()) {
                 $table->createDefaultSection($entity->get('id'));
             }
+        }
+
+        // Publish survey
+        if (!empty($options['publishSurvey'])) {
+            $publishEvent = new Event((string)EventName::PUBLISH_SURVEY(), $this, [
+                'data' => [
+                    'action' => 'add_survey',
+                    'survey' => $this->getSurveyData($entity->get('id'), true),
+                ]
+            ]);
+            $this->getEventManager()->dispatch($publishEvent);
         }
     }
 

--- a/tests/TestCase/Model/Table/SurveysTableTest.php
+++ b/tests/TestCase/Model/Table/SurveysTableTest.php
@@ -3,8 +3,12 @@ namespace Qobo\Survey\Test\TestCase\Model\Table;
 
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
+use Cake\Event\EventList;
+use Cake\Event\EventManager;
+use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Qobo\Survey\Event\EventName;
 use Qobo\Survey\Model\Table\SurveysTable;
 
 /**
@@ -30,6 +34,7 @@ class SurveysTableTest extends TestCase
         'plugin.qobo/survey.survey_questions',
         'plugin.qobo/survey.survey_answers',
         'plugin.qobo/survey.survey_sections',
+        'plugin.qobo/survey.survey_results',
     ];
 
     /**
@@ -170,5 +175,21 @@ class SurveysTableTest extends TestCase
                 $this->assertNotEquals($oldAnswerOrder, $newAnwserOrder);
             }
         }
+    }
+
+    /**
+     * Test whether the publish event is called after an entity
+     */
+    public function testPublishEventIsCalled(): void
+    {
+        $eventManager = EventManager::instance();
+        $eventManager->setEventList(new EventList());
+
+        $surveyId = '00000000-0000-0000-0000-000000000001';
+        $entity = $this->Surveys->get($surveyId);
+        $entity->set('publish_date', Time::now());
+        $entity->set('expiry_date', new Time('next year'));
+        $result = $this->Surveys->save($entity, ['publishSurvey' => true]);
+        $this->assertEventFired((string)EventName::PUBLISH_SURVEY());
     }
 }


### PR DESCRIPTION
Moving survey publish event inside afterSave` event allows developers preventing entity persistence if the application's publish listener throws an exception