### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,9 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
-        }
-    ],
     "require": {
         "admad/cakephp-sequence": "^2.2",
-        "cakephp/cakephp": "^3.5 <3.7",
+        "cakephp/cakephp": "^3.8",
         "muffin/slug": "^1.2",
         "muffin/trash": "^2.1",
         "riesenia/cakephp-duplicatable": "^3.0"
@@ -63,6 +57,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-	"minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -12,11 +12,6 @@
 namespace Qobo\Survey\Controller;
 
 use App\Controller\AppController as BaseController;
-use Cake\Log\Log;
-use Cake\ORM\TableRegistry;
-use Cake\Utility\Inflector;
-use Exception;
-use RuntimeException;
 
 /**
  * @property \Qobo\Survey\Controller\Component\OrderComponent $Order

--- a/src/Controller/SurveyAnswersController.php
+++ b/src/Controller/SurveyAnswersController.php
@@ -38,7 +38,7 @@ class SurveyAnswersController extends AppController
         /**
          * @var \Qobo\Survey\Model\Table\SurveysTable $table
          */
-        $table = TableRegistry::get('Qobo/Survey.Surveys');
+        $table = TableRegistry::getTableLocator()->get('Qobo/Survey.Surveys');
         $this->Surveys = $table;
     }
 

--- a/src/Controller/SurveyAnswersController.php
+++ b/src/Controller/SurveyAnswersController.php
@@ -13,7 +13,6 @@ namespace Qobo\Survey\Controller;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
-use Qobo\Survey\Controller\AppController;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Controller/SurveyEntriesController.php
+++ b/src/Controller/SurveyEntriesController.php
@@ -3,7 +3,6 @@ namespace Qobo\Survey\Controller;
 
 use Cake\Log\Log;
 use Cake\ORM\TableRegistry;
-use Qobo\Survey\Controller\AppController;
 
 /**
  * SurveyEntries Controller

--- a/src/Controller/SurveyQuestionsController.php
+++ b/src/Controller/SurveyQuestionsController.php
@@ -14,7 +14,6 @@ namespace Qobo\Survey\Controller;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
-use Qobo\Survey\Controller\AppController;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Controller/SurveyResultsController.php
+++ b/src/Controller/SurveyResultsController.php
@@ -1,10 +1,6 @@
 <?php
 namespace Qobo\Survey\Controller;
 
-use Cake\ORM\Query;
-use Cake\ORM\TableRegistry;
-use Qobo\Survey\Controller\AppController;
-use Webmozart\Assert\Assert;
 
 /**
  * SurveyResults Controller

--- a/src/Controller/SurveyResultsController.php
+++ b/src/Controller/SurveyResultsController.php
@@ -1,7 +1,6 @@
 <?php
 namespace Qobo\Survey\Controller;
 
-
 /**
  * SurveyResults Controller
  *

--- a/src/Controller/SurveySectionsController.php
+++ b/src/Controller/SurveySectionsController.php
@@ -3,7 +3,6 @@ namespace Qobo\Survey\Controller;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
-use Qobo\Survey\Controller\AppController;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Controller/SurveysController.php
+++ b/src/Controller/SurveysController.php
@@ -14,11 +14,7 @@ namespace Qobo\Survey\Controller;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
-use Qobo\Survey\Controller\AppController;
-use Qobo\Survey\Event\EventName;
 use Qobo\Survey\Model\Entity\SurveyEntry;
-use Qobo\Survey\Model\Table\SurveyQuestionsTable;
-use Qobo\Survey\Model\Table\SurveyResultsTable;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Model/Entity/SurveyEntry.php
+++ b/src/Model/Entity/SurveyEntry.php
@@ -3,7 +3,6 @@ namespace Qobo\Survey\Model\Entity;
 
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 
 /**

--- a/src/Model/Entity/SurveyEntry.php
+++ b/src/Model/Entity/SurveyEntry.php
@@ -53,7 +53,7 @@ class SurveyEntry extends Entity
         try {
             $user = $table->get($this->get('resource_id'));
 
-            $result['displayField'] = $user->get($table->displayField());
+            $result['displayField'] = $user->get($table->getDisplayField());
         } catch (RecordNotFoundException $e) {
             $result['displayField'] = __d('Qobo/Survey', '{0} Instance: [{1}]', $this->get('resource'), $this->get('resource_id'));
         }

--- a/src/Model/Entity/SurveyQuestion.php
+++ b/src/Model/Entity/SurveyQuestion.php
@@ -11,10 +11,8 @@
  */
 namespace Qobo\Survey\Model\Entity;
 
-use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
-use Qobo\Survey\Model\Entity\SurveyEntryQuestion;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Model/Table/SurveyAnswersTable.php
+++ b/src/Model/Table/SurveyAnswersTable.php
@@ -78,21 +78,21 @@ class SurveyAnswersTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('answer')
             ->maxLength('answer', 4294967295)
-            ->allowEmpty('answer');
+            ->allowEmptyString('answer');
 
         $validator
             ->scalar('comment')
             ->maxLength('comment', 4294967295)
-            ->allowEmpty('comment');
+            ->allowEmptyString('comment');
 
         $validator
             ->dateTime('trashed')
-            ->allowEmpty('trashed');
+            ->allowEmptyDateTime('trashed');
 
         return $validator;
     }

--- a/src/Model/Table/SurveyAnswersTable.php
+++ b/src/Model/Table/SurveyAnswersTable.php
@@ -11,7 +11,6 @@
  */
 namespace Qobo\Survey\Model\Table;
 
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;

--- a/src/Model/Table/SurveyEntriesTable.php
+++ b/src/Model/Table/SurveyEntriesTable.php
@@ -75,34 +75,33 @@ class SurveyEntriesTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('status')
             ->maxLength('status', 255)
-            ->allowEmpty('status');
+            ->allowEmptyString('status');
 
         $validator
-            ->integer('grade')
-            ->allowEmpty('grade');
+            ->integer('grade');
 
         $validator
             ->scalar('context')
             ->maxLength('context', 4294967295)
-            ->allowEmpty('context');
+            ->allowEmptyString('context');
 
         $validator
             ->scalar('comment')
             ->maxLength('comment', 4294967295)
-            ->allowEmpty('comment');
+            ->allowEmptyString('comment');
 
         $validator
             ->dateTime('submit_date')
-            ->allowEmpty('submit_date');
+            ->allowEmptyDateTime('submit_date');
 
         $validator
             ->dateTime('trashed')
-            ->allowEmpty('trashed');
+            ->allowEmptyString('trashed');
 
         return $validator;
     }

--- a/src/Model/Table/SurveyEntryQuestionsTable.php
+++ b/src/Model/Table/SurveyEntryQuestionsTable.php
@@ -1,7 +1,6 @@
 <?php
 namespace Qobo\Survey\Model\Table;
 
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;

--- a/src/Model/Table/SurveyEntryQuestionsTable.php
+++ b/src/Model/Table/SurveyEntryQuestionsTable.php
@@ -71,20 +71,19 @@ class SurveyEntryQuestionsTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('status')
             ->maxLength('status', 255)
-            ->allowEmpty('status');
+            ->allowEmptyString('status');
 
         $validator
-            ->integer('score')
-            ->allowEmpty('score');
+            ->integer('score');
 
         $validator
             ->dateTime('trashed')
-            ->allowEmpty('trashed');
+            ->allowEmptyDateTime('trashed');
 
         return $validator;
     }

--- a/src/Model/Table/SurveyQuestionsTable.php
+++ b/src/Model/Table/SurveyQuestionsTable.php
@@ -12,8 +12,6 @@
 namespace Qobo\Survey\Model\Table;
 
 use Cake\Core\Configure;
-use Cake\Datasource\EntityInterface;
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;

--- a/src/Model/Table/SurveyQuestionsTable.php
+++ b/src/Model/Table/SurveyQuestionsTable.php
@@ -91,31 +91,29 @@ class SurveyQuestionsTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('question')
             ->maxLength('question', 4294967295)
             ->requirePresence('question', 'create')
-            ->notEmpty('question');
+            ->notEmptyString('question');
 
         $validator
             ->scalar('type')
             ->maxLength('type', 255)
             ->requirePresence('type', 'create')
-            ->notEmpty('type');
+            ->notEmptyString('type');
 
         $validator
-            ->boolean('active')
-            ->allowEmpty('active');
+            ->boolean('active');
 
         $validator
-            ->boolean('is_required')
-            ->allowEmpty('is_required');
+            ->boolean('is_required');
 
         $validator
             ->dateTime('trashed')
-            ->allowEmpty('trashed');
+            ->allowEmptyDateTime('trashed');
 
         return $validator;
     }

--- a/src/Model/Table/SurveyResultsTable.php
+++ b/src/Model/Table/SurveyResultsTable.php
@@ -14,7 +14,6 @@ namespace Qobo\Survey\Model\Table;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
 use Cake\Log\Log;
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;

--- a/src/Model/Table/SurveyResultsTable.php
+++ b/src/Model/Table/SurveyResultsTable.php
@@ -102,16 +102,16 @@ class SurveyResultsTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('result')
             ->maxLength('result', 4294967295)
-            ->allowEmpty('result');
+            ->allowEmptyString('result');
 
         $validator
             ->dateTime('trashed')
-            ->allowEmpty('trashed');
+            ->allowEmptyDateTime('trashed');
 
         return $validator;
     }

--- a/src/Model/Table/SurveySectionsTable.php
+++ b/src/Model/Table/SurveySectionsTable.php
@@ -1,8 +1,6 @@
 <?php
 namespace Qobo\Survey\Model\Table;
 
-use Cake\ORM\Query;
-use Cake\ORM\ResultSet;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;

--- a/src/Model/Table/SurveySectionsTable.php
+++ b/src/Model/Table/SurveySectionsTable.php
@@ -74,21 +74,20 @@ class SurveySectionsTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('name')
             ->maxLength('name', 255)
             ->requirePresence('name', 'create')
-            ->notEmpty('name');
+            ->notEmptyString('name');
 
         $validator
-            ->boolean('active')
-            ->allowEmpty('active');
+            ->boolean('active');
 
         $validator
             ->dateTime('trashed')
-            ->allowEmpty('trashed');
+            ->allowEmptyDateTime('trashed');
 
         return $validator;
     }

--- a/src/Model/Table/SurveysTable.php
+++ b/src/Model/Table/SurveysTable.php
@@ -93,33 +93,32 @@ class SurveysTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('name')
             ->maxLength('name', 255)
-            ->allowEmpty('name');
+            ->allowEmptyString('name');
 
         $validator
-            ->notEmpty('slug')
+            ->notEmptyString('slug')
             ->add('slug', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $validator
-            ->allowEmpty('version');
+            ->allowEmptyString('version');
 
         $validator
             ->scalar('description')
             ->maxLength('description', 4294967295)
             ->requirePresence('description', 'create')
-            ->notEmpty('description');
+            ->notEmptyString('description');
 
         $validator
-            ->boolean('active')
-            ->allowEmpty('active');
+            ->boolean('active');
 
         $validator
             ->dateTime('trashed')
-            ->allowEmpty('trashed');
+            ->allowEmptyDateTime('trashed');
 
         return $validator;
     }
@@ -324,12 +323,12 @@ class SurveysTable extends Table
         /**
          * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $questions
          */
-        $questions = TableRegistry::get('Qobo/Survey.SurveyQuestions');
+        $questions = TableRegistry::getTableLocator()->get('Qobo/Survey.SurveyQuestions');
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveyAnswersTable $answers
          */
-        $answers = TableRegistry::get('Qobo/Survey.SurveyAnswers');
+        $answers = TableRegistry::getTableLocator()->get('Qobo/Survey.SurveyAnswers');
 
         $query = $questions->find()
             ->where(['survey_id' => $entity->get('id')])

--- a/src/Shell/Task/MigrateToEntriesTask.php
+++ b/src/Shell/Task/MigrateToEntriesTask.php
@@ -2,7 +2,6 @@
 namespace Qobo\Survey\Shell\Task;
 
 use Cake\Console\Shell;
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 
 /**

--- a/src/Template/Surveys/view.ctp
+++ b/src/Template/Surveys/view.ctp
@@ -12,7 +12,7 @@
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 
-$table = TableRegistry::get($this->name);
+$table = TableRegistry::getTableLocator()->get($this->name);
 
 echo $this->Html->scriptBlock('var apiToken="' . Configure::read('API.token') . '";', ['block' => 'scriptBottom']);
 echo $this->Html->css([

--- a/src/View/Helper/SurveyHelper.php
+++ b/src/View/Helper/SurveyHelper.php
@@ -1,10 +1,8 @@
 <?php
 namespace Qobo\Survey\View\Helper;
 
-use Cake\Datasource\EntityInterface;
 use Cake\View\Helper;
 use Qobo\Survey\Model\Entity\SurveyAnswer;
-use Qobo\Survey\Model\Entity\SurveyQuestion;
 
 class SurveyHelper extends Helper
 {

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -14,7 +14,6 @@
  */
 namespace Qobo\Survey\Test\App;
 
-use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\BaseApplication;
 use Cake\Routing\Middleware\AssetMiddleware;

--- a/tests/TestCase/Controller/SurveyAnswersControllerTest.php
+++ b/tests/TestCase/Controller/SurveyAnswersControllerTest.php
@@ -18,12 +18,12 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
 {
 
     public $fixtures = [
-        'plugin.qobo/survey.survey_results',
-        'plugin.qobo/survey.survey_questions',
-        'plugin.qobo/survey.survey_answers',
-        'plugin.qobo/survey.survey_sections',
-        'plugin.qobo/survey.surveys',
-        'plugin.qobo/survey.users',
+        'plugin.Qobo/Survey.SurveyResults',
+        'plugin.Qobo/Survey.SurveyQuestions',
+        'plugin.Qobo/Survey.SurveyAnswers',
+        'plugin.Qobo/Survey.SurveySections',
+        'plugin.Qobo/Survey.Surveys',
+        'plugin.Qobo/Survey.Users',
     ];
 
     public function setUp()

--- a/tests/TestCase/Controller/SurveyAnswersControllerTest.php
+++ b/tests/TestCase/Controller/SurveyAnswersControllerTest.php
@@ -1,10 +1,9 @@
 <?php
 namespace Qobo\Survey\Test\TestCase\Controller;
 
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\IntegrationTestCase;
-use Qobo\Survey\Controller\SurveysController;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Qobo\Survey\Model\Table\SurveyAnswersTable;
 use Qobo\Survey\Model\Table\SurveyQuestionsTable;
 use Qobo\Survey\Model\Table\SurveysTable;
@@ -14,8 +13,9 @@ use Qobo\Survey\Model\Table\SurveysTable;
  * @property \Qobo\Survey\Model\Table\SurveyQuestionsTable $SurveyQuestions
  * @property \Qobo\Survey\Model\Table\SurveyAnswersTable $SurveyAnswers
  */
-class SurveyAnswersControllerTest extends IntegrationTestCase
+class SurveyAnswersControllerTest extends TestCase
 {
+    use IntegrationTestTrait;
 
     public $fixtures = [
         'plugin.Qobo/Survey.SurveyResults',
@@ -33,26 +33,26 @@ class SurveyAnswersControllerTest extends IntegrationTestCase
         $userId = '00000000-0000-0000-0000-000000000001';
         $this->session([
             'Auth' => [
-                'User' => TableRegistry::get('Users')->get($userId)->toArray(),
+                'User' => TableRegistry::getTableLocator()->get('Users')->get($userId)->toArray(),
             ],
         ]);
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveysTable $table
          */
-        $table = TableRegistry::get('Surveys', ['className' => SurveysTable::class]);
+        $table = TableRegistry::getTableLocator()->get('Surveys', ['className' => SurveysTable::class]);
         $this->Surveys = $table;
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $table
          */
-        $table = TableRegistry::get('SurveyQuestions', ['className' => SurveyQuestionsTable::class]);
+        $table = TableRegistry::getTableLocator()->get('SurveyQuestions', ['className' => SurveyQuestionsTable::class]);
         $this->SurveyQuestions = $table;
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveyAnswersTable $table
          */
-        $table = TableRegistry::get('SurveyAnswers', ['className' => SurveyAnswersTable::class]);
+        $table = TableRegistry::getTableLocator()->get('SurveyAnswers', ['className' => SurveyAnswersTable::class]);
         $this->SurveyAnswers = $table;
     }
 

--- a/tests/TestCase/Controller/SurveyQuestionsControllerTest.php
+++ b/tests/TestCase/Controller/SurveyQuestionsControllerTest.php
@@ -3,13 +3,14 @@ namespace Qobo\Survey\Test\TestCase\Controller;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\IntegrationTestCase;
-use Qobo\Survey\Controller\SurveysController;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Qobo\Survey\Model\Table\SurveyQuestionsTable;
 use Qobo\Survey\Model\Table\SurveysTable;
 
-class SurveyQuestionsControllerTest extends IntegrationTestCase
+class SurveyQuestionsControllerTest extends TestCase
 {
+    use IntegrationTestTrait;
 
     public $fixtures = [
         'plugin.Qobo/Survey.SurveyResults',
@@ -37,20 +38,20 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
         $userId = '00000000-0000-0000-0000-000000000001';
         $this->session([
             'Auth' => [
-                'User' => TableRegistry::get('Users')->get($userId)->toArray(),
+                'User' => TableRegistry::getTableLocator()->get('Users')->get($userId)->toArray(),
             ],
         ]);
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveysTable $table
          */
-        $table = TableRegistry::get('Survey.Surveys', ['className' => SurveysTable::class]);
+        $table = TableRegistry::getTableLocator()->get('Survey.Surveys', ['className' => SurveysTable::class]);
         $this->Surveys = $table;
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $table
          */
-        $table = TableRegistry::get('Survey.SurveyQuestions', ['className' => SurveyQuestionsTable::class]);
+        $table = TableRegistry::getTableLocator()->get('Survey.SurveyQuestions', ['className' => SurveyQuestionsTable::class]);
         $this->SurveyQuestions = $table;
     }
 

--- a/tests/TestCase/Controller/SurveyQuestionsControllerTest.php
+++ b/tests/TestCase/Controller/SurveyQuestionsControllerTest.php
@@ -12,12 +12,12 @@ class SurveyQuestionsControllerTest extends IntegrationTestCase
 {
 
     public $fixtures = [
-        'plugin.qobo/survey.survey_results',
-        'plugin.qobo/survey.survey_questions',
-        'plugin.qobo/survey.survey_answers',
-        'plugin.qobo/survey.survey_sections',
-        'plugin.qobo/survey.surveys',
-        'plugin.qobo/survey.users',
+        'plugin.Qobo/Survey.SurveyResults',
+        'plugin.Qobo/Survey.SurveyQuestions',
+        'plugin.Qobo/Survey.SurveyAnswers',
+        'plugin.Qobo/Survey.SurveySections',
+        'plugin.Qobo/Survey.Surveys',
+        'plugin.Qobo/Survey.Users',
     ];
 
     /**

--- a/tests/TestCase/Controller/SurveySectionsControllerTest.php
+++ b/tests/TestCase/Controller/SurveySectionsControllerTest.php
@@ -2,16 +2,18 @@
 namespace Qobo\Survey\Test\TestCase\Controller;
 
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\IntegrationTestCase;
-use Qobo\Survey\Controller\SurveySectionsController;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Qobo\Survey\Model\Table\SurveySectionsTable;
 use Qobo\Survey\Model\Table\SurveysTable;
 
 /**
  * Qobo\Survey\Controller\SurveySectionsController Test Case
  */
-class SurveySectionsControllerTest extends IntegrationTestCase
+class SurveySectionsControllerTest extends TestCase
 {
+    use IntegrationTestTrait;
+
     /**
      * @var \Qobo\Survey\Model\Table\SurveysTable
      */

--- a/tests/TestCase/Controller/SurveySectionsControllerTest.php
+++ b/tests/TestCase/Controller/SurveySectionsControllerTest.php
@@ -28,12 +28,12 @@ class SurveySectionsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-         'plugin.qobo/survey.survey_results',
-         'plugin.qobo/survey.survey_questions',
-         'plugin.qobo/survey.survey_answers',
-         'plugin.qobo/survey.survey_sections',
-         'plugin.qobo/survey.surveys',
-         'plugin.qobo/survey.users',
+         'plugin.Qobo/Survey.SurveyResults',
+         'plugin.Qobo/Survey.SurveyQuestions',
+         'plugin.Qobo/Survey.SurveyAnswers',
+         'plugin.Qobo/Survey.SurveySections',
+         'plugin.Qobo/Survey.Surveys',
+         'plugin.Qobo/Survey.Users',
      ];
 
     /**

--- a/tests/TestCase/Controller/SurveysControllerTest.php
+++ b/tests/TestCase/Controller/SurveysControllerTest.php
@@ -3,15 +3,15 @@ namespace Qobo\Survey\Test\TestCase\Controller;
 
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\IntegrationTestCase;
-use Qobo\Survey\Controller\SurveysController;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Qobo\Survey\Model\Table\SurveyEntriesTable;
 use Qobo\Survey\Model\Table\SurveyResultsTable;
 use Qobo\Survey\Model\Table\SurveysTable;
-use Webmozart\Assert\Assert;
 
-class SurveysControllerTest extends IntegrationTestCase
+class SurveysControllerTest extends TestCase
 {
+    use IntegrationTestTrait;
 
     public $fixtures = [
         'plugin.Qobo/Survey.SurveyResults',
@@ -46,26 +46,26 @@ class SurveysControllerTest extends IntegrationTestCase
         $userId = '00000000-0000-0000-0000-000000000001';
         $this->session([
             'Auth' => [
-                'User' => TableRegistry::get('Users')->get($userId)->toArray(),
+                'User' => TableRegistry::getTableLocator()->get('Users')->get($userId)->toArray(),
             ],
         ]);
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveysTable $table
          */
-        $table = TableRegistry::get('Qobo/Survey.Surveys', ['className' => SurveysTable::class]);
+        $table = TableRegistry::getTableLocator()->get('Qobo/Survey.Surveys', ['className' => SurveysTable::class]);
         $this->Surveys = $table;
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveyResultsTable $table
          */
-        $table = TableRegistry::get('Qobo/Survey.SurveyResults', ['className' => SurveyResultsTable::class]);
+        $table = TableRegistry::getTableLocator()->get('Qobo/Survey.SurveyResults', ['className' => SurveyResultsTable::class]);
         $this->SurveyResults = $table;
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveyEntriesTable $table
          */
-        $table = TableRegistry::get('Qobo/Survey.SurveyEntries', ['className' => SurveyEntriesTable::class]);
+        $table = TableRegistry::getTableLocator()->get('Qobo/Survey.SurveyEntries', ['className' => SurveyEntriesTable::class]);
         $this->SurveyEntries = $table;
     }
 

--- a/tests/TestCase/Controller/SurveysControllerTest.php
+++ b/tests/TestCase/Controller/SurveysControllerTest.php
@@ -14,14 +14,14 @@ class SurveysControllerTest extends IntegrationTestCase
 {
 
     public $fixtures = [
-        'plugin.qobo/survey.survey_results',
-        'plugin.qobo/survey.survey_questions',
-        'plugin.qobo/survey.survey_answers',
-        'plugin.qobo/survey.survey_entries',
-        'plugin.qobo/survey.survey_entry_questions',
-        'plugin.qobo/survey.survey_sections',
-        'plugin.qobo/survey.surveys',
-        'plugin.qobo/survey.users',
+        'plugin.Qobo/Survey.SurveyResults',
+        'plugin.Qobo/Survey.SurveyQuestions',
+        'plugin.Qobo/Survey.SurveyAnswers',
+        'plugin.Qobo/Survey.SurveyEntries',
+        'plugin.Qobo/Survey.SurveyEntryQuestions',
+        'plugin.Qobo/Survey.SurveySections',
+        'plugin.Qobo/Survey.Surveys',
+        'plugin.Qobo/Survey.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/SurveyAnswersTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyAnswersTableTest.php
@@ -39,11 +39,11 @@ class SurveyAnswersTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Survey.SurveyAnswers') ? [] : ['className' => SurveyAnswersTable::class];
+        $config = TableRegistry::getTableLocator()->exists('Survey.SurveyAnswers') ? [] : ['className' => SurveyAnswersTable::class];
         /**
          * @var \Qobo\Survey\Model\Table\SurveyAnswersTable $table
          */
-        $table = TableRegistry::get('Survey.SurveyAnswers', $config);
+        $table = TableRegistry::getTableLocator()->get('Survey.SurveyAnswers', $config);
         $this->SurveyAnswers = $table;
     }
 

--- a/tests/TestCase/Model/Table/SurveyAnswersTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyAnswersTableTest.php
@@ -24,11 +24,11 @@ class SurveyAnswersTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/survey.survey_answers',
-        'plugin.qobo/survey.survey_questions',
-        'plugin.qobo/survey.surveys',
-        'plugin.qobo/survey.survey_results',
-        'plugin.qobo/survey.users',
+        'plugin.Qobo/Survey.SurveyQuestions',
+        'plugin.Qobo/Survey.SurveyAnswers',
+        'plugin.Qobo/Survey.SurveyResults',
+        'plugin.Qobo/Survey.Surveys',
+        'plugin.Qobo/Survey.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/SurveyEntriesTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyEntriesTableTest.php
@@ -21,13 +21,13 @@ class SurveyEntriesTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/survey.survey_answers',
-        'plugin.qobo/survey.survey_results',
-        'plugin.qobo/survey.survey_entries',
-        'plugin.qobo/survey.survey_questions',
-        'plugin.qobo/survey.survey_entry_questions',
-        'plugin.qobo/survey.surveys',
-        'plugin.qobo/survey.users',
+        'plugin.Qobo/Survey.SurveyAnswers',
+        'plugin.Qobo/Survey.SurveyResults',
+        'plugin.Qobo/Survey.SurveyEntries',
+        'plugin.Qobo/Survey.SurveyQuestions',
+        'plugin.Qobo/Survey.SurveyEntryQuestions',
+        'plugin.Qobo/Survey.Surveys',
+        'plugin.Qobo/Survey.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/SurveyQuestionsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyQuestionsTableTest.php
@@ -24,8 +24,8 @@ class SurveyQuestionsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/survey.survey_questions',
-        'plugin.qobo/survey.surveys',
+        'plugin.Qobo/Survey.SurveyQuestions',
+        'plugin.Qobo/Survey.Surveys',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/SurveyQuestionsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyQuestionsTableTest.php
@@ -36,11 +36,11 @@ class SurveyQuestionsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Survey.SurveyQuestions') ? [] : ['className' => SurveyQuestionsTable::class];
+        $config = TableRegistry::getTableLocator()->exists('Survey.SurveyQuestions') ? [] : ['className' => SurveyQuestionsTable::class];
         /**
          * @var \Qobo\Survey\Model\Table\SurveyQuestionsTable $table
          */
-        $table = TableRegistry::get('Survey.SurveyQuestions', $config);
+        $table = TableRegistry::getTableLocator()->get('Survey.SurveyQuestions', $config);
         $this->SurveyQuestions = $table;
     }
 

--- a/tests/TestCase/Model/Table/SurveyResultsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyResultsTableTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Qobo\Survey\Test\TestCase\Model\Table;
 
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Qobo\Survey\Model\Table\SurveyResultsTable;

--- a/tests/TestCase/Model/Table/SurveyResultsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyResultsTableTest.php
@@ -47,17 +47,17 @@ class SurveyResultsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Qobo\Survey.SurveyResults') ? [] : ['className' => SurveyResultsTable::class];
+        $config = TableRegistry::getTableLocator()->exists('Qobo\Survey.SurveyResults') ? [] : ['className' => SurveyResultsTable::class];
         /**
          * @var \Qobo\Survey\Model\Table\SurveyResultsTable $table
          */
-        $table = TableRegistry::get('SurveyResults', $config);
+        $table = TableRegistry::getTableLocator()->get('SurveyResults', $config);
         $this->SurveyResults = $table;
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveysTable $table
          */
-        $table = TableRegistry::get('Surveys', ['className' => SurveysTable::class]);
+        $table = TableRegistry::getTableLocator()->get('Surveys', ['className' => SurveysTable::class]);
         $this->Surveys = $table;
     }
 

--- a/tests/TestCase/Model/Table/SurveyResultsTableTest.php
+++ b/tests/TestCase/Model/Table/SurveyResultsTableTest.php
@@ -31,12 +31,12 @@ class SurveyResultsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/survey.survey_results',
-        'plugin.qobo/survey.surveys',
-        'plugin.qobo/survey.survey_questions',
-        'plugin.qobo/survey.survey_answers',
-        'plugin.qobo/survey.survey_sections',
-        'plugin.qobo/survey.users',
+        'plugin.Qobo/Survey.SurveyResults',
+        'plugin.Qobo/Survey.Surveys',
+        'plugin.Qobo/Survey.SurveyQuestions',
+        'plugin.Qobo/Survey.SurveyAnswers',
+        'plugin.Qobo/Survey.SurveySections',
+        'plugin.Qobo/Survey.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/SurveysTableTest.php
+++ b/tests/TestCase/Model/Table/SurveysTableTest.php
@@ -30,11 +30,11 @@ class SurveysTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.qobo/survey.surveys',
-        'plugin.qobo/survey.survey_questions',
-        'plugin.qobo/survey.survey_answers',
-        'plugin.qobo/survey.survey_sections',
-        'plugin.qobo/survey.survey_results',
+        'plugin.Qobo/Survey.Surveys',
+        'plugin.Qobo/Survey.SurveyQuestions',
+        'plugin.Qobo/Survey.SurveyAnswers',
+        'plugin.Qobo/Survey.SurveySections',
+        'plugin.Qobo/Survey.SurveyResults',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/SurveysTableTest.php
+++ b/tests/TestCase/Model/Table/SurveysTableTest.php
@@ -45,7 +45,7 @@ class SurveysTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Surveys') ? [] : ['className' => SurveysTable::class];
+        $config = TableRegistry::getTableLocator()->exists('Surveys') ? [] : ['className' => SurveysTable::class];
 
         /**
          * @var \Qobo\Survey\Model\Table\SurveysTable $table

--- a/tests/TestCase/Model/Table/SurveysTableTest.php
+++ b/tests/TestCase/Model/Table/SurveysTableTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Qobo\Survey\Test\TestCase\Model\Table;
 
-use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventList;
 use Cake\Event\EventManager;


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.

